### PR TITLE
[ROCKETMQ-3] Clean up and perfect the unit test of rocketmq-broker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,6 @@
                         <exclude>com/alibaba/rocketmq/common/protocol/MQProtosHelperTest.java</exclude>
                         <exclude>com/alibaba/rocketmq/client/consumer/loadbalance/AllocateMessageQueueAveragelyTest.java</exclude>
                         <exclude>com/alibaba/rocketmq/store/RecoverTest.java</exclude>
-                        <exclude>com/alibaba/rocketmq/broker/api/SendMessageTest.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/BrokerTestHarness.java
+++ b/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/BrokerTestHarness.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * $Id: SendMessageTest.java 1831 2013-05-16 01:39:51Z shijia.wxr $
+ */
+package com.alibaba.rocketmq.broker;
+
+import com.alibaba.rocketmq.common.BrokerConfig;
+import com.alibaba.rocketmq.remoting.netty.NettyClientConfig;
+import com.alibaba.rocketmq.remoting.netty.NettyServerConfig;
+import com.alibaba.rocketmq.store.config.MessageStoreConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author zander
+ */
+public class BrokerTestHarness {
+
+    protected BrokerController brokerController = null;
+
+    public final String BROKER_NAME = "TestBrokerName";
+    protected String brokerAddr = "";
+    protected Logger logger = LoggerFactory.getLogger(BrokerTestHarness.class);
+    protected BrokerConfig brokerConfig = new BrokerConfig();
+    protected NettyServerConfig nettyServerConfig = new NettyServerConfig();
+    protected NettyClientConfig nettyClientConfig = new NettyClientConfig();
+    protected MessageStoreConfig storeConfig = new MessageStoreConfig();
+
+    @Before
+    public void startup() throws Exception {
+        brokerConfig.setBrokerName(BROKER_NAME);
+        brokerConfig.setBrokerIP1("127.0.0.1");
+        nettyServerConfig.setListenPort(10911);
+        brokerAddr = brokerConfig.getBrokerIP1() + ":" + nettyServerConfig.getListenPort();
+        brokerController = new BrokerController(brokerConfig, nettyServerConfig, nettyClientConfig, storeConfig);
+        boolean initResult = brokerController.initialize();
+        logger.info("Broker Start name:{} addr:{}", brokerConfig.getBrokerName(), brokerController.getBrokerAddr());
+        brokerController.start();
+    }
+
+    @After
+    public void shutdown() throws Exception {
+        if (brokerController != null) {
+            brokerController.shutdown();
+        }
+    }
+}

--- a/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/BrokerTestHarness.java
+++ b/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/BrokerTestHarness.java
@@ -25,9 +25,13 @@ import com.alibaba.rocketmq.remoting.netty.NettyClientConfig;
 import com.alibaba.rocketmq.remoting.netty.NettyServerConfig;
 import com.alibaba.rocketmq.store.config.MessageStoreConfig;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.Random;
 
 /**
  * @author zander
@@ -36,6 +40,7 @@ public class BrokerTestHarness {
 
     protected BrokerController brokerController = null;
 
+    protected Random random = new Random();
     public final String BROKER_NAME = "TestBrokerName";
     protected String brokerAddr = "";
     protected Logger logger = LoggerFactory.getLogger(BrokerTestHarness.class);
@@ -48,10 +53,13 @@ public class BrokerTestHarness {
     public void startup() throws Exception {
         brokerConfig.setBrokerName(BROKER_NAME);
         brokerConfig.setBrokerIP1("127.0.0.1");
-        nettyServerConfig.setListenPort(10911);
+        storeConfig.setStorePathRootDir(System.getProperty("user.home") + File.separator + "unitteststore");
+        storeConfig.setStorePathCommitLog(System.getProperty("user.home") + File.separator + "unitteststore" + File.separator + "commitlog");
+        nettyServerConfig.setListenPort(10000 + random.nextInt(1000));
         brokerAddr = brokerConfig.getBrokerIP1() + ":" + nettyServerConfig.getListenPort();
         brokerController = new BrokerController(brokerConfig, nettyServerConfig, nettyClientConfig, storeConfig);
         boolean initResult = brokerController.initialize();
+        Assert.assertTrue(initResult);
         logger.info("Broker Start name:{} addr:{}", brokerConfig.getBrokerName(), brokerController.getBrokerAddr());
         brokerController.start();
     }
@@ -61,5 +69,6 @@ public class BrokerTestHarness {
         if (brokerController != null) {
             brokerController.shutdown();
         }
+        //maybe need to clean the file store. But we do not suggest deleting anything.
     }
 }

--- a/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/api/SendMessageTest.java
+++ b/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/api/SendMessageTest.java
@@ -20,68 +20,68 @@
  */
 package com.alibaba.rocketmq.broker.api;
 
-import com.alibaba.rocketmq.broker.BrokerController;
+import com.alibaba.rocketmq.broker.BrokerTestHarness;
+import com.alibaba.rocketmq.client.ClientConfig;
 import com.alibaba.rocketmq.client.hook.SendMessageContext;
 import com.alibaba.rocketmq.client.impl.CommunicationMode;
 import com.alibaba.rocketmq.client.impl.MQClientAPIImpl;
 import com.alibaba.rocketmq.client.producer.SendResult;
-import com.alibaba.rocketmq.common.BrokerConfig;
+import com.alibaba.rocketmq.client.producer.SendStatus;
 import com.alibaba.rocketmq.common.MixAll;
 import com.alibaba.rocketmq.common.message.Message;
 import com.alibaba.rocketmq.common.message.MessageDecoder;
 import com.alibaba.rocketmq.common.protocol.header.SendMessageRequestHeader;
 import com.alibaba.rocketmq.remoting.netty.NettyClientConfig;
-import com.alibaba.rocketmq.remoting.netty.NettyServerConfig;
-import com.alibaba.rocketmq.store.config.MessageStoreConfig;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 
 /**
- * @author shijia.wxr
+ * @author zander
  */
-public class SendMessageTest {
-    @Test
-    public void test_sendMessage() throws Exception {
-        BrokerController brokerController = new BrokerController(//
-                new BrokerConfig(), //
-                new NettyServerConfig(), //
-                new NettyClientConfig(), //
-                new MessageStoreConfig());
-        boolean initResult = brokerController.initialize();
-        System.out.println("initialize " + initResult);
+public class SendMessageTest extends BrokerTestHarness{
 
-        brokerController.start();
+    MQClientAPIImpl client = new MQClientAPIImpl(new NettyClientConfig(), null, null, new ClientConfig());
+    String topic = "UnitTestTopic";
 
-        MQClientAPIImpl client = new MQClientAPIImpl(new NettyClientConfig(), null, null, null);
+    @Before
+    @Override
+    public void startup() throws Exception {
+        super.startup();
         client.start();
 
-        for (int i = 0; i < 100; i++) {
-            String topic = "UnitTestTopic_" + i % 3;
-            Message msg = new Message(topic, "TAG1 TAG2", "100200300", ("Hello, Nice world\t" + i).getBytes());
-            msg.setDelayTimeLevel(i % 3 + 1);
+    }
 
-            try {
-                SendMessageRequestHeader requestHeader = new SendMessageRequestHeader();
-                requestHeader.setProducerGroup("abc");
-                requestHeader.setTopic(msg.getTopic());
-                requestHeader.setDefaultTopic(MixAll.DEFAULT_TOPIC);
-                requestHeader.setDefaultTopicQueueNums(4);
-                requestHeader.setQueueId(i % 4);
-                requestHeader.setSysFlag(0);
-                requestHeader.setBornTimestamp(System.currentTimeMillis());
-                requestHeader.setFlag(msg.getFlag());
-                requestHeader.setProperties(MessageDecoder.messageProperties2String(msg.getProperties()));
-
-                SendResult result = client.sendMessage("127.0.0.1:10911", "brokerName", msg, requestHeader, 1000 * 5,
-                        CommunicationMode.SYNC, new SendMessageContext(), null);
-                System.out.println(i + "\t" + result);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        }
-
+    @After
+    @Override
+    public void shutdown() throws Exception {
         client.shutdown();
+        super.shutdown();
+    }
 
-        brokerController.shutdown();
+    @Test
+    public void testSendSingle() throws Exception {
+        Message msg = new Message(topic, "TAG1 TAG2", "100200300", "body".getBytes());
+        try {
+            SendMessageRequestHeader requestHeader = new SendMessageRequestHeader();
+            requestHeader.setProducerGroup("abc");
+            requestHeader.setTopic(msg.getTopic());
+            requestHeader.setDefaultTopic(MixAll.DEFAULT_TOPIC);
+            requestHeader.setDefaultTopicQueueNums(4);
+            requestHeader.setQueueId(0);
+            requestHeader.setSysFlag(0);
+            requestHeader.setBornTimestamp(System.currentTimeMillis());
+            requestHeader.setFlag(msg.getFlag());
+            requestHeader.setProperties(MessageDecoder.messageProperties2String(msg.getProperties()));
+
+            SendResult result = client.sendMessage(brokerAddr, BROKER_NAME, msg, requestHeader, 1000 * 5,
+                    CommunicationMode.SYNC, new SendMessageContext(), null);
+            assertTrue(result.getSendStatus() == SendStatus.SEND_OK);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/topic/TopicConfigManagerTest.java
+++ b/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/topic/TopicConfigManagerTest.java
@@ -20,14 +20,9 @@
  */
 package com.alibaba.rocketmq.broker.topic;
 
-import com.alibaba.rocketmq.broker.BrokerController;
 import com.alibaba.rocketmq.broker.BrokerTestHarness;
-import com.alibaba.rocketmq.common.BrokerConfig;
 import com.alibaba.rocketmq.common.MixAll;
 import com.alibaba.rocketmq.common.TopicConfig;
-import com.alibaba.rocketmq.remoting.netty.NettyClientConfig;
-import com.alibaba.rocketmq.remoting.netty.NettyServerConfig;
-import com.alibaba.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;

--- a/rocketmq-broker/src/test/resources/logback-test.xml
+++ b/rocketmq-broker/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="DefaultAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <append>true</append>
+        <encoder>
+            <pattern>%d{yyy-MM-dd HH\:mm\:ss,GMT+8} %p %t - %m%n</pattern>
+            <charset class="java.nio.charset.Charset">UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <root>
+        <level value="OFF"/>
+        <appender-ref ref="DefaultAppender"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Clean up and perfect the unit test of rocketmq-broker.
Add BrokerTestHarness as a base class to create temporary BrokerController.
Flush test has three steps:
1 persist to the disk
2 clear the in-memory values
3 load from the disk.
Used for both testFlushConsumerOffset and testFlushTopicConfig