### PR TITLE
[ROCKETMQ-32] Improve concision - Reuse local variable 'brokerAddrs' in RouteInfoManager.getSystemTopicList method

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-RocketMQ
-Copyright 2016 Alibaba Group.
+Apache RocketMQ (incubating)
+Copyright 2016 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/bin/mqbroker
+++ b/bin/mqbroker
@@ -42,6 +42,4 @@ fi
 
 export ROCKETMQ_HOME
 
-rm -f $HOME/rmq_bk_gc.log.bac
-cp $HOME/rmq_bk_gc.log $HOME/rmq_bk_gc.log.bac
 sh ${ROCKETMQ_HOME}/bin/runbroker.sh org.apache.rocketmq.broker.BrokerStartup $@

--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerController.java
@@ -463,7 +463,7 @@ public class BrokerController {
         final Runnable peek = q.peek();
         if (peek != null) {
             RequestTask rt = BrokerFastFailure.castRunnable(peek);
-            slowTimeMills = this.messageStore.now() - rt.getCreateTimestamp();
+            slowTimeMills = rt == null ? 0 : this.messageStore.now() - rt.getCreateTimestamp();
         }
 
         if (slowTimeMills < 0)

--- a/broker/src/main/java/org/apache/rocketmq/broker/latency/BrokerFastFailure.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/latency/BrokerFastFailure.java
@@ -71,7 +71,7 @@ public class BrokerFastFailure {
                 } else {
                     break;
                 }
-            } catch (Throwable e) {
+            } catch (Throwable ignored) {
             }
         }
 
@@ -99,7 +99,7 @@ public class BrokerFastFailure {
                 } else {
                     break;
                 }
-            } catch (Throwable e) {
+            } catch (Throwable ignored) {
             }
         }
     }

--- a/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PullRequestHoldService.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/longpolling/PullRequestHoldService.java
@@ -130,7 +130,7 @@ public class PullRequestHoldService extends ServiceThread {
                     if (newestOffset > request.getPullFromThisOffset()) {
                         if (this.messageFilter.isMessageMatched(request.getSubscriptionData(), tagsCode)) {
                             try {
-                                this.brokerController.getPullMessageProcessor().excuteRequestWhenWakeup(request.getClientChannel(),
+                                this.brokerController.getPullMessageProcessor().executeRequestWhenWakeup(request.getClientChannel(),
                                     request.getRequestCommand());
                             } catch (Throwable e) {
                                 log.error("execute request when wakeup failed.", e);
@@ -141,7 +141,7 @@ public class PullRequestHoldService extends ServiceThread {
 
                     if (System.currentTimeMillis() >= (request.getSuspendTimestamp() + request.getTimeoutMillis())) {
                         try {
-                            this.brokerController.getPullMessageProcessor().excuteRequestWhenWakeup(request.getClientChannel(),
+                            this.brokerController.getPullMessageProcessor().executeRequestWhenWakeup(request.getClientChannel(),
                                 request.getRequestCommand());
                         } catch (Throwable e) {
                             log.error("execute request when wakeup failed.", e);

--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/PullMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/PullMessageProcessor.java
@@ -50,6 +50,7 @@ import org.apache.rocketmq.remoting.common.RemotingHelper;
 import org.apache.rocketmq.remoting.common.RemotingUtil;
 import org.apache.rocketmq.remoting.exception.RemotingCommandException;
 import org.apache.rocketmq.remoting.netty.NettyRequestProcessor;
+import org.apache.rocketmq.remoting.netty.RequestTask;
 import org.apache.rocketmq.remoting.protocol.RemotingCommand;
 import org.apache.rocketmq.store.GetMessageResult;
 import org.apache.rocketmq.store.MessageExtBrokerInner;
@@ -481,7 +482,7 @@ public class PullMessageProcessor implements NettyRequestProcessor {
         }
     }
 
-    public void excuteRequestWhenWakeup(final Channel channel, final RemotingCommand request) throws RemotingCommandException {
+    public void executeRequestWhenWakeup(final Channel channel, final RemotingCommand request) throws RemotingCommandException {
         Runnable run = new Runnable() {
             @Override
             public void run() {
@@ -513,8 +514,7 @@ public class PullMessageProcessor implements NettyRequestProcessor {
                 }
             }
         };
-
-        this.brokerController.getPullMessageExecutor().submit(run);
+        this.brokerController.getPullMessageExecutor().submit(new RequestTask(run, channel, request));
     }
 
     public void registerConsumeMessageHook(List<ConsumeMessageHook> sendMessageHookList) {

--- a/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
@@ -142,8 +142,8 @@ public class SubscriptionGroupManager extends ConfigManager {
 
     @Override
     public String configFilePath() {
-        //return BrokerPathConfigHelper.getSubscriptionGroupPath(this.brokerController.getMessageStoreConfig().getStorePathRootDir());
-        return BrokerPathConfigHelper.getSubscriptionGroupPath(System.getProperty("user.home") + File.separator + "store");
+        return BrokerPathConfigHelper.getSubscriptionGroupPath(this.brokerController.getMessageStoreConfig()
+                .getStorePathRootDir());
     }
 
     @Override

--- a/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/subscription/SubscriptionGroupManager.java
@@ -16,7 +16,6 @@
  */
 package org.apache.rocketmq.broker.subscription;
 
-import java.io.File;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -16,7 +16,6 @@
  */
 package org.apache.rocketmq.broker.topic;
 
-import java.io.File;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;

--- a/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/topic/TopicConfigManager.java
@@ -381,9 +381,8 @@ public class TopicConfigManager extends ConfigManager {
 
     @Override
     public String configFilePath() {
-//        return BrokerPathConfigHelper.getTopicConfigPath(this.brokerController.getMessageStoreConfig()
-//                .getStorePathRootDir());
-        return BrokerPathConfigHelper.getTopicConfigPath(System.getProperty("user.home") + File.separator + "store");
+        return BrokerPathConfigHelper.getTopicConfigPath(this.brokerController.getMessageStoreConfig()
+                .getStorePathRootDir());
     }
 
     @Override

--- a/broker/src/test/java/org/apache/rocketmq/broker/api/BrokerFastFailureTest.java
+++ b/broker/src/test/java/org/apache/rocketmq/broker/api/BrokerFastFailureTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.broker.api;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.broker.BrokerTestHarness;
+import org.apache.rocketmq.broker.latency.BrokerFastFailure;
+import org.apache.rocketmq.broker.latency.FutureTaskExt;
+import org.apache.rocketmq.remoting.netty.RequestTask;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BrokerFastFailureTest extends BrokerTestHarness {
+
+    @Test
+    public void testHeadSlowTimeMills() throws InterruptedException {
+        BlockingQueue<Runnable> blockingQueue = new LinkedBlockingQueue<>();
+        blockingQueue.add(new FutureTaskExt<>(new RequestTask(null, null, null), null));
+        TimeUnit.MILLISECONDS.sleep(10);
+        Assert.assertTrue(this.brokerController.headSlowTimeMills(blockingQueue) > 0);
+
+        blockingQueue.clear();
+        blockingQueue.add(new Runnable() {
+            @Override public void run() {
+
+            }
+        });
+        Assert.assertTrue(this.brokerController.headSlowTimeMills(blockingQueue) == 0);
+    }
+
+    @Test
+    public void testCastRunnable() {
+        Runnable runnable = new Runnable() {
+            @Override public void run() {
+
+            }
+        };
+        Assert.assertNull(BrokerFastFailure.castRunnable(runnable));
+
+        RequestTask requestTask = new RequestTask(null, null, null);
+        runnable = new FutureTaskExt<>(requestTask, null);
+
+        Assert.assertEquals(requestTask, BrokerFastFailure.castRunnable(runnable));
+    }
+}

--- a/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/DefaultMQPushConsumer.java
@@ -40,51 +40,116 @@ import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.exception.RemotingException;
 
 /**
- * Wrapped push consumer.in fact,it works as remarkable as the pull consumer
+ * In most scenarios, this is the mostly recommended class to consume messages.
+ * </p>
+ *
+ * Technically speaking, this push client is virtually a wrapper of the underlying pull service. Specifically, on
+ * arrival of messages pulled from brokers, it roughly invokes the registered callback handler to feed the messages.
+ * </p>
+ *
+ * See quickstart/Consumer in the example module for a typical usage.
+ * </p>
+ *
+ * <p>
+ *     <strong>Thread Safety:</strong> After initialization, the instance can be regarded as thread-safe.
+ * </p>
  */
 public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsumer {
-    protected final transient DefaultMQPushConsumerImpl defaultMQPushConsumerImpl;
+
     /**
-     * Do the same thing for the same Group, the application must be set,and
-     * guarantee Globally unique
+     * Internal implementation. Most of the functions herein are delegated to it.
+     */
+    protected final transient DefaultMQPushConsumerImpl defaultMQPushConsumerImpl;
+
+    /**
+     * Consumers of the same role is required to have exactly same subscriptions and consumerGroup to correctly achieve
+     * load balance. It's required and needs to be globally unique.
+     * </p>
+     *
+     * See <a href="http://rocketmq.incubator.apache.org/docs/core-concept/">here</a> for further discussion.
      */
     private String consumerGroup;
+
     /**
-     * Consumption pattern,default is clustering
+     * Message model defines the way how messages are delivered to each consumer clients.
+     * </p>
+     *
+     * RocketMQ supports two message models: clustering and broadcasting. If clustering is set, consumer clients with
+     * the same {@link #consumerGroup} would only consume shards of the messages subscribed, which achieves load
+     * balances; Conversely, if the broadcasting is set, each consumer client will consume all subscribed messages
+     * separately.
+     * </p>
+     *
+     * This field defaults to clustering.
      */
     private MessageModel messageModel = MessageModel.CLUSTERING;
+
     /**
-     * Consumption offset
+     * Consuming point on consumer booting.
+     * </p>
+     *
+     * There are three consuming points:
+     * <ul>
+     *     <li>
+     *         <code>CONSUME_FROM_LAST_OFFSET</code>: consumer clients pick up where it stopped previously.
+     *         If it were a newly booting up consumer client, according aging of the consumer group, there are two
+     *         cases:
+     *         <ol>
+     *             <li>
+     *                 if the consumer group is created so recently that the earliest message being subscribed has yet
+     *                 expired, which means the consumer group represents a lately launched business, consuming will
+     *                 start from the very beginning;
+     *             </li>
+     *             <li>
+     *                 if the earliest message being subscribed has expired, consuming will start from the latest
+     *                 messages, meaning messages born prior to the booting timestamp would be ignored.
+     *             </li>
+     *         </ol>
+     *     </li>
+     *     <li>
+     *         <code>CONSUME_FROM_FIRST_OFFSET</code>: Consumer client will start from earliest messages available.
+     *     </li>
+     *     <li>
+     *         <code>CONSUME_FROM_TIMESTAMP</code>: Consumer client will start from specified timestamp, which means
+     *         messages born prior to {@link #consumeTimestamp} will be ignored
+     *     </li>
+     * </ul>
      */
     private ConsumeFromWhere consumeFromWhere = ConsumeFromWhere.CONSUME_FROM_LAST_OFFSET;
+
     /**
-     * Backtracking consumption time with second precision.time format is
+     * Backtracking consumption time with second precision. Time format is
      * 20131223171201<br>
      * Implying Seventeen twelve and 01 seconds on December 23, 2013 year<br>
-     * Default backtracking consumption time Half an hour ago
+     * Default backtracking consumption time Half an hour ago.
      */
     private String consumeTimestamp = UtilAll.timeMillisToHumanString3(System.currentTimeMillis() - (1000 * 60 * 30));
+
     /**
-     * Queue allocation algorithm
+     * Queue allocation algorithm specifying how message queues are allocated to each consumer clients.
      */
     private AllocateMessageQueueStrategy allocateMessageQueueStrategy;
 
     /**
      * Subscription relationship
      */
-    private Map<String /* topic */, String /* sub expression */> subscription = new HashMap<String, String>();
+    private Map<String /* topic */, String /* sub expression */> subscription = new HashMap<>();
+
     /**
      * Message listener
      */
     private MessageListener messageListener;
+
     /**
      * Offset Storage
      */
     private OffsetStore offsetStore;
+
     /**
      * Minimum consumer thread number
      */
     private int consumeThreadMin = 20;
+
     /**
      * Max consumer thread number
      */
@@ -99,18 +164,22 @@ public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsume
      * Concurrently max span offset.it has no effect on sequential consumption
      */
     private int consumeConcurrentlyMaxSpan = 2000;
+
     /**
      * Flow control threshold
      */
     private int pullThresholdForQueue = 1000;
+
     /**
      * Message pull Interval
      */
     private long pullInterval = 0;
+
     /**
      * Batch consumption size
      */
     private int consumeMessageBatchMaxSize = 1;
+
     /**
      * Batch pull size
      */
@@ -126,24 +195,56 @@ public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsume
      */
     private boolean unitMode = false;
 
+    /**
+     * Max re-consume times. -1 means 16 times.
+     * </p>
+     *
+     * If messages are re-consumed more than {@link #maxReconsumeTimes} before success, it's be directed to a deletion
+     * queue waiting.
+     */
     private int maxReconsumeTimes = -1;
+
+    /**
+     * Suspending pulling time for cases requiring slow pulling like flow-control scenario.
+     */
     private long suspendCurrentQueueTimeMillis = 1000;
+
+    /**
+     * Maximum amount of time in minutes a message may block the consuming thread.
+     */
     private long consumeTimeout = 15;
 
+    /**
+     * Default constructor.
+     */
     public DefaultMQPushConsumer() {
         this(MixAll.DEFAULT_CONSUMER_GROUP, null, new AllocateMessageQueueAveragely());
     }
 
+    /**
+     * Constructor specifying consumer group, RPC hook and message queue allocating algorithm.
+     * @param consumerGroup Consume queue.
+     * @param rpcHook RPC hook to execute before each remoting command.
+     * @param allocateMessageQueueStrategy message queue allocating algorithm.
+     */
     public DefaultMQPushConsumer(final String consumerGroup, RPCHook rpcHook, AllocateMessageQueueStrategy allocateMessageQueueStrategy) {
         this.consumerGroup = consumerGroup;
         this.allocateMessageQueueStrategy = allocateMessageQueueStrategy;
         defaultMQPushConsumerImpl = new DefaultMQPushConsumerImpl(this, rpcHook);
     }
 
+    /**
+     * Constructor specifying RPC hook.
+     * @param rpcHook RPC hook to execute before each remoting command.
+     */
     public DefaultMQPushConsumer(RPCHook rpcHook) {
         this(MixAll.DEFAULT_CONSUMER_GROUP, rpcHook, new AllocateMessageQueueAveragely());
     }
 
+    /**
+     * Constructor specifying consumer group.
+     * @param consumerGroup Consumer group.
+     */
     public DefaultMQPushConsumer(final String consumerGroup) {
         this(consumerGroup, null, new AllocateMessageQueueAveragely());
     }
@@ -308,12 +409,33 @@ public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsume
         this.subscription = subscription;
     }
 
+    /**
+     * Send message back to broker which will be re-delivered in future.
+     * @param msg Message to send back.
+     * @param delayLevel delay level.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any broker error.
+     * @throws InterruptedException if the thread is interrupted.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public void sendMessageBack(MessageExt msg, int delayLevel)
         throws RemotingException, MQBrokerException, InterruptedException, MQClientException {
         this.defaultMQPushConsumerImpl.sendMessageBack(msg, delayLevel, null);
     }
 
+    /**
+     * Send message back to the broker whose name is <code>brokerName</code> and the message will be re-delivered in
+     * future.
+     *
+     * @param msg Message to send back.
+     * @param delayLevel delay level.
+     * @param brokerName broker name.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any broker error.
+     * @throws InterruptedException if the thread is interrupted.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public void sendMessageBack(MessageExt msg, int delayLevel, String brokerName)
         throws RemotingException, MQBrokerException, InterruptedException, MQClientException {
@@ -325,11 +447,18 @@ public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsume
         return this.defaultMQPushConsumerImpl.fetchSubscribeMessageQueues(topic);
     }
 
+    /**
+     * This method gets internal infrastructure readily to serve. Instances must call this method after configuration.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public void start() throws MQClientException {
         this.defaultMQPushConsumerImpl.start();
     }
 
+    /**
+     * Shut down this client and releasing underlying resources.
+     */
     @Override
     public void shutdown() {
         this.defaultMQPushConsumerImpl.shutdown();
@@ -342,43 +471,83 @@ public class DefaultMQPushConsumer extends ClientConfig implements MQPushConsume
         this.defaultMQPushConsumerImpl.registerMessageListener(messageListener);
     }
 
+    /**
+     * Register a callback to execute on message arrival for concurrent consuming.
+     *
+     * @param messageListener message handling callback.
+     */
     @Override
     public void registerMessageListener(MessageListenerConcurrently messageListener) {
         this.messageListener = messageListener;
         this.defaultMQPushConsumerImpl.registerMessageListener(messageListener);
     }
 
+    /**
+     * Register a callback to execute on message arrival for orderly consuming.
+     *
+     * @param messageListener message handling callback.
+     */
     @Override
     public void registerMessageListener(MessageListenerOrderly messageListener) {
         this.messageListener = messageListener;
         this.defaultMQPushConsumerImpl.registerMessageListener(messageListener);
     }
 
+    /**
+     * Subscribe a topic to consuming subscription.
+     *
+     * @param topic topic to subscribe.
+     * @param subExpression subscription expression.it only support or operation such as "tag1 || tag2 || tag3" <br>
+     *     if null or * expression,meaning subscribe all
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public void subscribe(String topic, String subExpression) throws MQClientException {
         this.defaultMQPushConsumerImpl.subscribe(topic, subExpression);
     }
 
+    /**
+     * Subscribe a topic to consuming subscription.
+     * @param topic topic to consume.
+     * @param fullClassName full class name,must extend org.apache.rocketmq.common.filter. MessageFilter
+     * @param filterClassSource class source code,used UTF-8 file encoding,must be responsible for your code safety
+     * @throws MQClientException
+     */
     @Override
     public void subscribe(String topic, String fullClassName, String filterClassSource) throws MQClientException {
         this.defaultMQPushConsumerImpl.subscribe(topic, fullClassName, filterClassSource);
     }
 
+    /**
+     * Un-subscribe the specified topic from subscription.
+     * @param topic message topic
+     */
     @Override
     public void unsubscribe(String topic) {
         this.defaultMQPushConsumerImpl.unsubscribe(topic);
     }
 
+    /**
+     * Update the message consuming thread core pool size.
+     *
+     * @param corePoolSize new core pool size.
+     */
     @Override
     public void updateCorePoolSize(int corePoolSize) {
         this.defaultMQPushConsumerImpl.updateCorePoolSize(corePoolSize);
     }
 
+    /**
+     * Suspend pulling new messages.
+     */
     @Override
     public void suspend() {
         this.defaultMQPushConsumerImpl.suspend();
     }
 
+    /**
+     * Resume pulling.
+     */
     @Override
     public void resume() {
         this.defaultMQPushConsumerImpl.resume();

--- a/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/MQAdminImpl.java
@@ -23,6 +23,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.apache.rocketmq.client.QueryResult;
 import org.apache.rocketmq.client.exception.MQBrokerException;
 import org.apache.rocketmq.client.exception.MQClientException;
@@ -285,6 +288,7 @@ public class MQAdminImpl {
             if (!brokerAddrs.isEmpty()) {
                 final CountDownLatch countDownLatch = new CountDownLatch(brokerAddrs.size());
                 final List<QueryResult> queryResultList = new LinkedList<QueryResult>();
+                final ReadWriteLock lock = new ReentrantReadWriteLock(false);
 
                 for (String addr : brokerAddrs) {
                     try {
@@ -318,7 +322,12 @@ public class MQAdminImpl {
                                                         MessageDecoder.decodes(ByteBuffer.wrap(response.getBody()), true);
 
                                                     QueryResult qr = new QueryResult(responseHeader.getIndexLastUpdateTimestamp(), wrappers);
-                                                    queryResultList.add(qr);
+                                                    try {
+                                                        lock.writeLock().lock();
+                                                        queryResultList.add(qr);
+                                                    } finally {
+                                                        lock.writeLock().unlock();
+                                                    }
                                                     break;
                                                 }
                                                 default:

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageConcurrentlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageConcurrentlyService.java
@@ -439,7 +439,11 @@ public class ConsumeMessageConcurrentlyService implements ConsumeMessageService 
             } else if (ConsumeConcurrentlyStatus.CONSUME_SUCCESS == status) {
                 returnType = ConsumeReturnType.SUCCESS;
             }
-            consumeMessageContext.getProps().put(MixAll.CONSUME_CONTEXT_TYPE, returnType.name());
+
+            if (ConsumeMessageConcurrentlyService.this.defaultMQPushConsumerImpl.hasHook()) {
+                consumeMessageContext.getProps().put(MixAll.CONSUME_CONTEXT_TYPE, returnType.name());
+            }
+
             if (null == status) {
                 log.warn("consumeMessage return null, Group: {} Msgs: {} MQ: {}",
                     ConsumeMessageConcurrentlyService.this.consumerGroup,

--- a/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/consumer/ConsumeMessageOrderlyService.java
@@ -501,7 +501,11 @@ public class ConsumeMessageOrderlyService implements ConsumeMessageService {
                             } else if (ConsumeOrderlyStatus.SUCCESS == status) {
                                 returnType = ConsumeReturnType.SUCCESS;
                             }
-                            consumeMessageContext.getProps().put(MixAll.CONSUME_CONTEXT_TYPE, returnType.name());
+
+                            if (ConsumeMessageOrderlyService.this.defaultMQPushConsumerImpl.hasHook()) {
+                                consumeMessageContext.getProps().put(MixAll.CONSUME_CONTEXT_TYPE, returnType.name());
+                            }
+
                             if (null == status) {
                                 status = ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT;
                             }

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -321,94 +321,252 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
         this.defaultMQProducerImpl.send(msg, mq, sendCallback);
     }
 
+    /**
+     * Same to {@link #send(Message, SendCallback)} with target message queue and send timeout specified.
+     * @param msg Message to send.
+     * @param mq Target message queue.
+     * @param sendCallback Callback to execute on sending completed, either successful or unsuccessful.
+     * @param timeout Send timeout.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void send(Message msg, MessageQueue mq, SendCallback sendCallback, long timeout)
         throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.send(msg, mq, sendCallback, timeout);
     }
 
+    /**
+     * Same to {@link #sendOneway(Message)} with target message queue specified.
+     * @param msg Message to send.
+     * @param mq Target message queue.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void sendOneway(Message msg, MessageQueue mq) throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.sendOneway(msg, mq);
     }
 
+    /**
+     *  Same to {@link #send(Message)} with message queue selector specified.
+     *
+     * @param msg Message to send.
+     * @param selector Message queue selector, through which we get target message queue to deliver message to.
+     * @param arg Argument to work along with message queue selector.
+     * @return {@link SendResult} instance to inform senders details of the deliverable, say Message ID of the message,
+     * {@link SendStatus} indicating broker storage/replication status, message queue sent to, etc.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any error with broker.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public SendResult send(Message msg, MessageQueueSelector selector, Object arg)
         throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         return this.defaultMQProducerImpl.send(msg, selector, arg);
     }
 
+    /**
+     * Same to {@link #send(Message, MessageQueueSelector, Object)} with send timeout specified.
+     *
+     * @param msg Message to send.
+     * @param selector Message queue selector, through which we get target message queue to deliver message to.
+     * @param arg Argument to work along with message queue selector.
+     * @param timeout Send timeout.
+     * @return {@link SendResult} instance to inform senders details of the deliverable, say Message ID of the message,
+     * {@link SendStatus} indicating broker storage/replication status, message queue sent to, etc.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any error with broker.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public SendResult send(Message msg, MessageQueueSelector selector, Object arg, long timeout)
         throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         return this.defaultMQProducerImpl.send(msg, selector, arg, timeout);
     }
 
+    /**
+     * Same to {@link #send(Message, SendCallback)} with message queue selector specified.
+     *
+     * @param msg Message to send.
+     * @param selector Message selector through which to get target message queue.
+     * @param arg Argument used along with message queue selector.
+     * @param sendCallback callback to execute on sending completion.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void send(Message msg, MessageQueueSelector selector, Object arg, SendCallback sendCallback)
         throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.send(msg, selector, arg, sendCallback);
     }
 
+    /**
+     * Same to {@link #send(Message, MessageQueueSelector, Object, SendCallback)} with timeout specified.
+     *
+     * @param msg Message to send.
+     * @param selector Message selector through which to get target message queue.
+     * @param arg Argument used along with message queue selector.
+     * @param sendCallback callback to execute on sending completion.
+     * @param timeout Send timeout.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void send(Message msg, MessageQueueSelector selector, Object arg, SendCallback sendCallback, long timeout)
         throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.send(msg, selector, arg, sendCallback, timeout);
     }
 
+    /**
+     * Same to {@link #sendOneway(Message)} with message queue selector specified.
+     * @param msg Message to send.
+     * @param selector Message queue selector, through which to determine target message queue to deliver message
+     * @param arg Argument used along with message queue selector.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void sendOneway(Message msg, MessageQueueSelector selector, Object arg)
         throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.sendOneway(msg, selector, arg);
     }
 
+    /**
+     * This method is to send transactional messages.
+     *
+     * @param msg Transactional message to send.
+     * @param tranExecuter local transaction executor.
+     * @param arg Argument used along with local transaction executor.
+     * @return Transaction result.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public TransactionSendResult sendMessageInTransaction(Message msg, LocalTransactionExecuter tranExecuter, final Object arg)
         throws MQClientException {
         throw new RuntimeException("sendMessageInTransaction not implement, please use TransactionMQProducer class");
     }
 
+    /**
+     * Create a topic on broker.
+     * @param key accesskey
+     * @param newTopic topic name
+     * @param queueNum topic's queue number
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public void createTopic(String key, String newTopic, int queueNum) throws MQClientException {
         createTopic(key, newTopic, queueNum, 0);
     }
 
+    /**
+     * Create a topic on broker.
+     * @param key accesskey
+     * @param newTopic topic name
+     * @param queueNum topic's queue number
+     * @param topicSysFlag topic system flag
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public void createTopic(String key, String newTopic, int queueNum, int topicSysFlag) throws MQClientException {
         this.defaultMQProducerImpl.createTopic(key, newTopic, queueNum, topicSysFlag);
     }
 
+    /**
+     * Search consume queue offset of the given time stamp.
+     * @param mq Instance of MessageQueue
+     * @param timestamp from when in milliseconds.
+     * @return Consume queue offset.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public long searchOffset(MessageQueue mq, long timestamp) throws MQClientException {
         return this.defaultMQProducerImpl.searchOffset(mq, timestamp);
     }
 
+    /**
+     * Query maximum offset of the given message queue.
+     *
+     * @param mq Instance of MessageQueue
+     * @return maximum offset of the given consume queue.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public long maxOffset(MessageQueue mq) throws MQClientException {
         return this.defaultMQProducerImpl.maxOffset(mq);
     }
 
+    /**
+     * Query minimum offset of the given message queue.
+     * @param mq Instance of MessageQueue
+     * @return minimum offset of the given message queue.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public long minOffset(MessageQueue mq) throws MQClientException {
         return this.defaultMQProducerImpl.minOffset(mq);
     }
 
+    /**
+     * Query earliest message store time.
+     * @param mq Instance of MessageQueue
+     * @return earliest message store time.
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public long earliestMsgStoreTime(MessageQueue mq) throws MQClientException {
         return this.defaultMQProducerImpl.earliestMsgStoreTime(mq);
     }
 
+    /**
+     * Query message of the given offset message ID.
+     * @param offsetMsgId message id
+     * @return Message specified.
+     * @throws MQBrokerException if there is any broker error.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public MessageExt viewMessage(String offsetMsgId) throws RemotingException, MQBrokerException, InterruptedException, MQClientException {
         return this.defaultMQProducerImpl.viewMessage(offsetMsgId);
     }
 
+    /**
+     * Query message by key.
+     * @param topic message topic
+     * @param key message key index word
+     * @param maxNum max message number
+     * @param begin from when
+     * @param end to when
+     * @return QueryResult instance contains matched messages.
+     * @throws MQClientException if there is any client error.
+     * @throws InterruptedException if the thread is interrupted.
+     */
     @Override
     public QueryResult queryMessage(String topic, String key, int maxNum, long begin, long end)
         throws MQClientException, InterruptedException {
         return this.defaultMQProducerImpl.queryMessage(topic, key, maxNum, begin, end);
     }
 
+    /**
+     * Query message of the given message ID.
+     *
+     * @param topic Topic
+     * @param msgId Message ID
+     * @return Message specified.
+     * @throws MQBrokerException if there is any broker error.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public MessageExt viewMessage(String topic, String msgId) throws RemotingException, MQBrokerException, InterruptedException, MQClientException {
         try {

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -31,92 +31,290 @@ import org.apache.rocketmq.common.message.MessageQueue;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.remoting.exception.RemotingException;
 
+/**
+ * This class is the entry point for applications intending to send messages.
+ * </p>
+ *
+ * It's fine to tune fields which exposes getter/setter methods, but keep in mind, all of them should work well out of
+ * box for most scenarios.
+ * </p>
+ *
+ * This class aggregates various <code>send</code> methods to deliver messages to brokers. Each of them has pros and
+ * cons; you'd better understand strengths and weakness of them before actually coding.
+ * </p>
+ *
+ * <p>
+ *     <strong>Thread Safety:</strong> After configuring and starting process, this class can be regarded as thread-safe
+ *     and used among multiple threads context.
+ * </p>
+ */
 public class DefaultMQProducer extends ClientConfig implements MQProducer {
+
+    /**
+     * Wrapping internal implementations for virtually all methods presented in this class.
+     */
     protected final transient DefaultMQProducerImpl defaultMQProducerImpl;
+
+    /**
+     * Producer group conceptually aggregates all producer instances of exactly same role, which is particularly
+     * important when transactional messages are involved.
+     * </p>
+     *
+     * For non-transactional messages, it does not matter as long as it's unique per process.
+     * </p>
+     *
+     * See {@linktourl http://rocketmq.incubator.apache.org/docs/core-concept/} for more discussion.
+     */
     private String producerGroup;
+
     /**
      * Just for testing or demo program
      */
     private String createTopicKey = MixAll.DEFAULT_TOPIC;
+
+    /**
+     * Number of queues to create per default topic.
+     */
     private volatile int defaultTopicQueueNums = 4;
+
+    /**
+     * Timeout for sending messages.
+     */
     private int sendMsgTimeout = 3000;
+
+    /**
+     * Compress message body threshold, namely, message body larger than 4k will be compressed on default.
+     */
     private int compressMsgBodyOverHowmuch = 1024 * 4;
+
+    /**
+     * Maximum number of retry to perform internally before claiming sending failure in synchronous mode.
+     * </p>
+     *
+     * This may potentially cause message duplication which is up to application developers to resolve.
+     */
     private int retryTimesWhenSendFailed = 2;
+
+    /**
+     * Maximum number of retry to perform internally before claiming sending failure in asynchronous mode.
+     * </p>
+     *
+     * This may potentially cause message duplication which is up to application developers to resolve.
+     */
     private int retryTimesWhenSendAsyncFailed = 2;
 
+    /**
+     * Indicate whether to retry another broker on sending failure internally.
+     */
     private boolean retryAnotherBrokerWhenNotStoreOK = false;
+
+    /**
+     * Maximum allowed message size in bytes.
+     */
     private int maxMessageSize = 1024 * 1024 * 4; // 4M
 
+    /**
+     * Default constructor.
+     */
     public DefaultMQProducer() {
         this(MixAll.DEFAULT_PRODUCER_GROUP, null);
     }
 
+    /**
+     * Constructor specifying both producer group and RPC hook.
+     *
+     * @param producerGroup Producer group, see the name-sake field.
+     * @param rpcHook RPC hook to execute per each remoting command execution.
+     */
     public DefaultMQProducer(final String producerGroup, RPCHook rpcHook) {
         this.producerGroup = producerGroup;
         defaultMQProducerImpl = new DefaultMQProducerImpl(this, rpcHook);
     }
 
+    /**
+     * Constructor specifying producer group.
+     * @param producerGroup Producer group, see the name-sake field.
+     */
     public DefaultMQProducer(final String producerGroup) {
         this(producerGroup, null);
     }
 
+    /**
+     * Constructor specifying the RPC hook.
+     * @param rpcHook RPC hook to execute per each remoting command execution.
+     */
     public DefaultMQProducer(RPCHook rpcHook) {
         this(MixAll.DEFAULT_PRODUCER_GROUP, rpcHook);
     }
 
+    /**
+     * Start this producer instance.
+     * </p>
+     *
+     * <strong>
+     * Much internal initializing procedures are carried out to make this instance prepared, thus, it's a must to invoke
+     * this method before sending or querying messages.
+     * </strong>
+     * </p>
+     *
+     * @throws MQClientException if there is any unexpected error.
+     */
     @Override
     public void start() throws MQClientException {
         this.defaultMQProducerImpl.start();
     }
 
+    /**
+     * This method shuts down this producer instance and releases related resources.
+     */
     @Override
     public void shutdown() {
         this.defaultMQProducerImpl.shutdown();
     }
 
+    /**
+     * Fetch message queues of topic <code>topic</code>, to which we may send/publish messages.
+     * @param topic Topic to fetch.
+     * @return List of message queues readily to send messages to
+     * @throws MQClientException if there is any client error.
+     */
     @Override
     public List<MessageQueue> fetchPublishMessageQueues(String topic) throws MQClientException {
         return this.defaultMQProducerImpl.fetchPublishMessageQueues(topic);
     }
 
+    /**
+     * Send message in synchronous mode. This method returns only when the sending procedure totally completes.
+     * </p>
+     *
+     * <strong>Warn:</strong> this method has internal retry-mechanism, that is, internal implementation will retry
+     * {@link #retryTimesWhenSendFailed} times before claiming failure. As a result, multiple messages may potentially
+     * delivered to broker(s). It's up to the application developers to resolve potential duplication issue.
+     *
+     * @param msg Message to send.
+     * @return {@link SendResult} instance to inform senders details of the deliverable, say Message ID of the message,
+     * {@link SendStatus} indicating broker storage/replication status, message queue sent to, etc.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any error with broker.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public SendResult send(Message msg) throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         return this.defaultMQProducerImpl.send(msg);
     }
 
+    /**
+     * Same to {@link #send(Message)} with send timeout specified in addition.
+     * @param msg Message to send.
+     * @param timeout send timeout.
+     * @return {@link SendResult} instance to inform senders details of the deliverable, say Message ID of the message,
+     * {@link SendStatus} indicating broker storage/replication status, message queue sent to, etc.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any error with broker.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public SendResult send(Message msg, long timeout) throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         return this.defaultMQProducerImpl.send(msg, timeout);
     }
 
+    /**
+     * Send message to broker asynchronously.
+     * </p>
+     *
+     * This method returns immediately. On sending completion, <code>sendCallback</code> will be executed.
+     * </p>
+     *
+     * Similar to {@link #send(Message)}, internal implementation would potentially retry up to
+     * {@link #retryTimesWhenSendAsyncFailed} times before claiming sending failure, which may yield message duplication
+     * and application developers are the one to resolve this potential issue.
+     * @param msg Message to send.
+     * @param sendCallback Callback to execute on sending completed, either successful or unsuccessful.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void send(Message msg, SendCallback sendCallback) throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.send(msg, sendCallback);
     }
 
+    /**
+     * Same to {@link #send(Message, SendCallback)} with send timeout specified in addition.
+     * @param msg message to send.
+     * @param sendCallback Callback to execute.
+     * @param timeout send timeout.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void send(Message msg, SendCallback sendCallback, long timeout)
         throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.send(msg, sendCallback, timeout);
     }
 
+    /**
+     * Similar to <a href="https://en.wikipedia.org/wiki/User_Datagram_Protocol">UDP</a>, this method won't wait for
+     * acknowledgement from broker before return. Obviously, it has maximums throughput yet potentials of message loss.
+     * @param msg Message to send.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void sendOneway(Message msg) throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.sendOneway(msg);
     }
 
+    /**
+     * Same to {@link #send(Message)} with target message queue specified in addition.
+     * @param msg Message to send.
+     * @param mq Target message queue.
+     * @return {@link SendResult} instance to inform senders details of the deliverable, say Message ID of the message,
+     * {@link SendStatus} indicating broker storage/replication status, message queue sent to, etc.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any error with broker.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public SendResult send(Message msg, MessageQueue mq)
         throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         return this.defaultMQProducerImpl.send(msg, mq);
     }
 
+    /**
+     * Same to {@link #send(Message)} with target message queue and send timeout specified.
+     *
+     * @param msg Message to send.
+     * @param mq Target message queue.
+     * @param timeout send timeout.
+     * @return {@link SendResult} instance to inform senders details of the deliverable, say Message ID of the message,
+     * {@link SendStatus} indicating broker storage/replication status, message queue sent to, etc.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws MQBrokerException if there is any error with broker.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public SendResult send(Message msg, MessageQueue mq, long timeout)
         throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         return this.defaultMQProducerImpl.send(msg, mq, timeout);
     }
 
+    /**
+     * Same to {@link #send(Message, SendCallback)} with target message queue specified.
+     *
+     * @param msg Message to send.
+     * @param mq Target message queue.
+     * @param sendCallback Callback to execute on sending completed, either successful or unsuccessful.
+     * @throws MQClientException if there is any client error.
+     * @throws RemotingException if there is any network-tier error.
+     * @throws InterruptedException if the sending thread is interrupted.
+     */
     @Override
     public void send(Message msg, MessageQueue mq, SendCallback sendCallback)
         throws MQClientException, RemotingException, InterruptedException {

--- a/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
+++ b/common/src/main/java/org/apache/rocketmq/common/BrokerConfig.java
@@ -91,7 +91,7 @@ public class BrokerConfig {
     private boolean slaveReadEnable = false;
 
     private boolean disableConsumeIfConsumerReadSlowly = false;
-    private long consumerFallbehindThreshold = 1024 * 1024 * 1024 * 16;
+    private long consumerFallbehindThreshold = 1024L * 1024 * 1024 * 16;
 
     private long waitTimeMillsInSendQueue = 200;
 

--- a/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/UtilAll.java
@@ -183,17 +183,16 @@ public class UtilAll {
 
         try {
             File file = new File(path);
-            if (!file.exists()) {
-                boolean result = file.mkdirs();
-                if (!result) {
-                    //TO DO
-                }
-            }
+
+            if (!file.exists())
+                return -1;
 
             long totalSpace = file.getTotalSpace();
-            long freeSpace = file.getFreeSpace();
-            long usedSpace = totalSpace - freeSpace;
+
             if (totalSpace > 0) {
+                long freeSpace = file.getFreeSpace();
+                long usedSpace = totalSpace - freeSpace;
+
                 return usedSpace / (double) totalSpace;
             }
         } catch (Exception e) {

--- a/common/src/test/java/org/apache/rocketmq/common/BrokerConfigTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/BrokerConfigTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BrokerConfigTest {
+
+    @Test
+    public void testConsumerFallBehindThresholdOverflow() {
+        long expect = 1024L * 1024 * 1024 * 16;
+        Assert.assertEquals(expect, new BrokerConfig().getConsumerFallbehindThreshold());
+    }
+
+}

--- a/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/UtilAllTest.java
@@ -21,6 +21,8 @@ import java.net.URL;
 import java.util.Properties;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class UtilAllTest {
@@ -76,6 +78,17 @@ public class UtilAllTest {
 
         System.out.println("PID = " + pid);
         assertTrue(pid > 0);
+    }
+
+    @Test
+    public void test_getDiskPartitionSpaceUsedPercent() {
+        assertEquals(-1, UtilAll.getDiskPartitionSpaceUsedPercent(null), 0);
+        assertEquals(-1, UtilAll.getDiskPartitionSpaceUsedPercent(""), 0);
+
+        assertEquals(-1, UtilAll.getDiskPartitionSpaceUsedPercent("nonExistingPath"), 0);
+
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        assertNotEquals(-1, UtilAll.getDiskPartitionSpaceUsedPercent(tmpDir), 0);
     }
 
     @Test

--- a/example/src/main/java/org/apache/rocketmq/example/filter/Consumer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/filter/Consumer.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.example.filter;
 
+import java.io.File;
 import java.util.List;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
@@ -30,8 +31,11 @@ public class Consumer {
     public static void main(String[] args) throws InterruptedException, MQClientException {
         DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("ConsumerGroupNamecc4");
 
-        String filterCode = MixAll.file2String("/home/admin/MessageFilterImpl.java");
-        consumer.subscribe("TopicFilter7", "org.apache.rocketmq.example.filter.MessageFilterImpl",
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        File classFile = new File(classLoader.getResource("MessageFilterImpl.java").getFile());
+
+        String filterCode = MixAll.file2String(classFile);
+        consumer.subscribe("TopicTest", "org.apache.rocketmq.example.filter.MessageFilterImpl",
             filterCode);
 
         consumer.registerMessageListener(new MessageListenerConcurrently() {

--- a/example/src/main/resources/MessageFilterImpl.java
+++ b/example/src/main/resources/MessageFilterImpl.java
@@ -17,13 +17,14 @@
 
 package org.apache.rocketmq.example.filter;
 
+import org.apache.rocketmq.common.filter.FilterContext;
 import org.apache.rocketmq.common.filter.MessageFilter;
 import org.apache.rocketmq.common.message.MessageExt;
 
 public class MessageFilterImpl implements MessageFilter {
 
     @Override
-    public boolean match(MessageExt msg) {
+    public boolean match(MessageExt msg, FilterContext context) {
         String property = msg.getProperty("SequenceId");
         if (property != null) {
             int id = Integer.parseInt(property);

--- a/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
+++ b/namesrv/src/main/java/org/apache/rocketmq/namesrv/routeinfo/RouteInfoManager.java
@@ -610,7 +610,7 @@ public class RouteInfoManager {
                     while (it.hasNext()) {
                         BrokerData bd = brokerAddrTable.get(it.next());
                         HashMap<Long, String> brokerAddrs = bd.getBrokerAddrs();
-                        if (bd.getBrokerAddrs() != null && !bd.getBrokerAddrs().isEmpty()) {
+                        if (brokerAddrs != null && !brokerAddrs.isEmpty()) {
                             Iterator<Long> it2 = brokerAddrs.keySet().iterator();
                             topicList.setBrokerAddr(brokerAddrs.get(it2.next()));
                             break;

--- a/release.xml
+++ b/release.xml
@@ -27,7 +27,7 @@
         <fileSet>
             <includes>
                 <include>bin/*</include>
-                <include>conf/*</include>
+                <include>conf/**</include>
                 <include>benchmark/*</include>
                 <include>LICENSE</include>
                 <include>NOTICE</include>

--- a/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/netty/NettyRemotingClient.java
@@ -73,12 +73,12 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
     private final Bootstrap bootstrap = new Bootstrap();
     private final EventLoopGroup eventLoopGroupWorker;
     private final Lock lockChannelTables = new ReentrantLock();
-    private final ConcurrentHashMap<String /* addr */, ChannelWrapper> channelTables = new ConcurrentHashMap<String, ChannelWrapper>();
+    private final ConcurrentHashMap<String /* addr */, ChannelWrapper> channelTables = new ConcurrentHashMap<>();
 
     private final Timer timer = new Timer("ClientHouseKeepingService", true);
 
-    private final AtomicReference<List<String>> namesrvAddrList = new AtomicReference<List<String>>();
-    private final AtomicReference<String> namesrvAddrChoosed = new AtomicReference<String>();
+    private final AtomicReference<List<String>> namesrvAddrList = new AtomicReference<>();
+    private final AtomicReference<String> namesrvAddrChoosed = new AtomicReference<>();
     private final AtomicInteger namesrvIndex = new AtomicInteger(initValueIndex());
     private final Lock lockNamesrvChannel = new ReentrantLock();
 
@@ -155,7 +155,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
                         new NettyEncoder(),
                         new NettyDecoder(),
                         new IdleStateHandler(0, 0, nettyClientConfig.getClientChannelMaxIdleTimeSeconds()),
-                        new NettyConnetManageHandler(),
+                        new NettyConnectManageHandler(),
                         new NettyClientHandler());
                 }
             });
@@ -527,7 +527,7 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
             executorThis = this.publicExecutor;
         }
 
-        Pair<NettyRequestProcessor, ExecutorService> pair = new Pair<NettyRequestProcessor, ExecutorService>(processor, executorThis);
+        Pair<NettyRequestProcessor, ExecutorService> pair = new Pair<>(processor, executorThis);
         this.processorTable.put(requestCode, pair);
     }
 
@@ -596,17 +596,18 @@ public class NettyRemotingClient extends NettyRemotingAbstract implements Remoti
         }
     }
 
-    class NettyConnetManageHandler extends ChannelDuplexHandler {
+    class NettyConnectManageHandler extends ChannelDuplexHandler {
         @Override
-        public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise)
-            throws Exception {
+        public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress,
+            ChannelPromise promise) throws Exception {
             final String local = localAddress == null ? "UNKNOW" : localAddress.toString();
             final String remote = remoteAddress == null ? "UNKNOW" : remoteAddress.toString();
             log.info("NETTY CLIENT PIPELINE: CONNECT  {} => {}", local, remote);
+
             super.connect(ctx, remoteAddress, localAddress, promise);
 
             if (NettyRemotingClient.this.channelEventListener != null) {
-                NettyRemotingClient.this.putNettyEvent(new NettyEvent(NettyEventType.CONNECT, remoteAddress.toString(), ctx.channel()));
+                NettyRemotingClient.this.putNettyEvent(new NettyEvent(NettyEventType.CONNECT, remote, ctx.channel()));
             }
         }
 

--- a/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CommitLog.java
@@ -1045,7 +1045,7 @@ public class CommitLog {
 
             while (!this.isStopped()) {
                 try {
-                    this.waitForRunning(0);
+                    this.waitForRunning(10);
                     this.doCommit();
                 } catch (Exception e) {
                     CommitLog.log.warn(this.getServiceName() + " service has exception. ", e);

--- a/store/src/main/java/org/apache/rocketmq/store/ha/HAService.java
+++ b/store/src/main/java/org/apache/rocketmq/store/ha/HAService.java
@@ -297,7 +297,7 @@ public class HAService {
 
             while (!this.isStopped()) {
                 try {
-                    this.waitForRunning(0);
+                    this.waitForRunning(10);
                     this.doWaitTransfer();
                 } catch (Exception e) {
                     log.warn(this.getServiceName() + " service has exception. ", e);

--- a/style/rmq_codeStyle.xml
+++ b/style/rmq_codeStyle.xml
@@ -55,7 +55,7 @@
     <option name="WHILE_ON_NEW_LINE" value="true"/>
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
     <option name="ALIGN_MULTILINE_FOR" value="false"/>
-    <option name="SPACE_AFTER_TYPE_CAST" value="false"/>
+    <option name="SPACE_AFTER_TYPE_CAST" value="true"/>
     <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
     <option name="METHOD_PARAMETERS_WRAP" value="1"/>
     <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true"/>
@@ -80,7 +80,6 @@
         <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
         <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
         <option name="ALIGN_MULTILINE_FOR" value="false"/>
-        <option name="SPACE_AFTER_TYPE_CAST" value="false"/>
         <option name="METHOD_PARAMETERS_WRAP" value="1"/>
         <option name="METHOD_ANNOTATION_WRAP" value="1"/>
         <option name="CLASS_ANNOTATION_WRAP" value="1"/>
@@ -102,7 +101,6 @@
         <option name="WHILE_ON_NEW_LINE" value="true"/>
         <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
         <option name="ALIGN_MULTILINE_FOR" value="false"/>
-        <option name="SPACE_AFTER_TYPE_CAST" value="false"/>
         <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true"/>
         <option name="METHOD_PARAMETERS_WRAP" value="1"/>
         <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true"/>

--- a/style/rmq_codeStyle.xml
+++ b/style/rmq_codeStyle.xml
@@ -52,10 +52,7 @@
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
-    <option name="ELSE_ON_NEW_LINE" value="true"/>
     <option name="WHILE_ON_NEW_LINE" value="true"/>
-    <option name="CATCH_ON_NEW_LINE" value="true"/>
-    <option name="FINALLY_ON_NEW_LINE" value="true"/>
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
     <option name="ALIGN_MULTILINE_FOR" value="false"/>
     <option name="SPACE_AFTER_TYPE_CAST" value="false"/>
@@ -81,9 +78,6 @@
         <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
         <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
         <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
         <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
         <option name="ALIGN_MULTILINE_FOR" value="false"/>
         <option name="SPACE_AFTER_TYPE_CAST" value="false"/>
@@ -105,10 +99,7 @@
         <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
         <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
         <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
         <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
         <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
         <option name="ALIGN_MULTILINE_FOR" value="false"/>
         <option name="SPACE_AFTER_TYPE_CAST" value="false"/>
@@ -132,10 +123,7 @@
         <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
         <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
         <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1"/>
-        <option name="ELSE_ON_NEW_LINE" value="true"/>
         <option name="WHILE_ON_NEW_LINE" value="true"/>
-        <option name="CATCH_ON_NEW_LINE" value="true"/>
-        <option name="FINALLY_ON_NEW_LINE" value="true"/>
         <option name="ALIGN_MULTILINE_PARAMETERS" value="false"/>
         <option name="ALIGN_MULTILINE_FOR" value="false"/>
         <option name="METHOD_PARAMETERS_WRAP" value="1"/>

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByKeySubCommand.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/message/QueryMsgByKeySubCommand.java
@@ -69,7 +69,7 @@ public class QueryMsgByKeySubCommand implements SubCommand {
         }
     }
 
-    void queryByKey(final DefaultMQAdminExt admin, final String topic, final String key)
+    private void queryByKey(final DefaultMQAdminExt admin, final String topic, final String key)
         throws MQClientException, InterruptedException {
         admin.start();
 


### PR DESCRIPTION
reuse brokerAddrs, or change like following:
`    if (bd.getBrokerAddrs() != null && !bd.getBrokerAddrs().isEmpty()) {
        Iterator<Long> it2 = bd.getBrokerAddrs().keySet().iterator();
        topicList.setBrokerAddr(bd.getBrokerAddrs().get(it2.next()));
        break;
    }`
