### PR TITLE
[ROCKETMQ-2] Broker tests fail with "Address already in use"

### DIFF
--- a/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/BrokerControllerTest.java
+++ b/rocketmq-broker/src/test/java/com/alibaba/rocketmq/broker/BrokerControllerTest.java
@@ -22,11 +22,15 @@ import com.alibaba.rocketmq.remoting.netty.NettyClientConfig;
 import com.alibaba.rocketmq.remoting.netty.NettyServerConfig;
 import com.alibaba.rocketmq.store.config.MessageStoreConfig;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author shtykh_roman
  */
 public class BrokerControllerTest {
+    protected Logger logger = LoggerFactory.getLogger(BrokerControllerTest.class);
+
     private static final int RESTART_NUM = 3;
 
     /**
@@ -44,10 +48,13 @@ public class BrokerControllerTest {
                 new NettyClientConfig(), //
                 new MessageStoreConfig());
             boolean initResult = brokerController.initialize();
-            System.out.println("initialize " + initResult);
+            logger.info("Broker is initialized " + initResult);
+
             brokerController.start();
+            logger.info("Broker is started");
 
             brokerController.shutdown();
+            logger.info("Broker is stopped");
         }
     }
 }

--- a/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/ha/HAService.java
+++ b/rocketmq-store/src/main/java/com/alibaba/rocketmq/store/ha/HAService.java
@@ -173,7 +173,7 @@ public class HAService {
     class AcceptSocketService extends ServiceThread {
         private ServerSocketChannel serverSocketChannel;
         private Selector selector;
-        private SocketAddress socketAddressListen;
+        private final SocketAddress socketAddressListen;
 
 
         public AcceptSocketService(final int port) {
@@ -194,7 +194,8 @@ public class HAService {
         public void shutdown(final boolean interrupt) {
             super.shutdown(interrupt);
             try {
-                serverSocketChannel.close();
+                this.serverSocketChannel.close();
+                this.selector.close();
             }
             catch (IOException e) {
                 log.error("AcceptSocketService shutdown exception", e);


### PR DESCRIPTION
Jira issue: https://issues.apache.org/jira/browse/ROCKETMQ-2

Closed the selector.