### PR TITLE
add new way to send messages in asynchronous way

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultMQProducerImpl.java
@@ -24,12 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
+
 import org.apache.rocketmq.client.QueryResult;
 import org.apache.rocketmq.client.Validators;
 import org.apache.rocketmq.client.common.ClientErrorCode;
@@ -44,16 +40,7 @@ import org.apache.rocketmq.client.impl.MQClientManager;
 import org.apache.rocketmq.client.impl.factory.MQClientInstance;
 import org.apache.rocketmq.client.latency.MQFaultStrategy;
 import org.apache.rocketmq.client.log.ClientLogger;
-import org.apache.rocketmq.client.producer.DefaultMQProducer;
-import org.apache.rocketmq.client.producer.LocalTransactionExecuter;
-import org.apache.rocketmq.client.producer.LocalTransactionState;
-import org.apache.rocketmq.client.producer.MessageQueueSelector;
-import org.apache.rocketmq.client.producer.SendCallback;
-import org.apache.rocketmq.client.producer.SendResult;
-import org.apache.rocketmq.client.producer.SendStatus;
-import org.apache.rocketmq.client.producer.TransactionCheckListener;
-import org.apache.rocketmq.client.producer.TransactionMQProducer;
-import org.apache.rocketmq.client.producer.TransactionSendResult;
+import org.apache.rocketmq.client.producer.*;
 import org.apache.rocketmq.common.MixAll;
 import org.apache.rocketmq.common.ServiceState;
 import org.apache.rocketmq.common.UtilAll;
@@ -412,10 +399,23 @@ public class DefaultMQProducerImpl implements MQProducerInner {
     public void send(Message msg, SendCallback sendCallback, long timeout)
         throws MQClientException, RemotingException, InterruptedException {
         try {
-            this.sendDefaultImpl(msg, CommunicationMode.ASYNC, sendCallback, timeout);
+            this.sendDefaultImpl(msg, CommunicationMode.ASYNC, sendCallback, timeout, null);
         } catch (MQBrokerException e) {
             throw new MQClientException("unknownn exception", e);
         }
+    }
+
+    public SendFuture send(Message message, Executor executor, long timeout) throws MQClientException, RemotingException {
+        SendPromise promise = new DefaultSendPromise(executor);
+        try {
+            this.sendDefaultImpl(message, CommunicationMode.ASYNC, null, timeout, promise);
+        } catch (MQBrokerException e) {
+            throw new MQClientException("unknownn exception", e);
+        } catch (InterruptedException e) {
+            // ignore
+        }
+
+        return promise;
     }
 
     public MessageQueue selectOneMessageQueue(final TopicPublishInfo tpInfo, final String lastBrokerName) {
@@ -430,7 +430,8 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         Message msg, //
         final CommunicationMode communicationMode, //
         final SendCallback sendCallback, //
-        final long timeout//
+        final long timeout,
+        final SendPromise promise
     ) throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         this.makeSureStateOK();
         Validators.checkMessage(msg, this.defaultMQProducer);
@@ -455,7 +456,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                     brokersSent[times] = mq.getBrokerName();
                     try {
                         beginTimestampPrev = System.currentTimeMillis();
-                        sendResult = this.sendKernelImpl(msg, mq, communicationMode, sendCallback, topicPublishInfo, timeout);
+                        sendResult = this.sendKernelImpl(msg, mq, communicationMode, sendCallback, topicPublishInfo, timeout, promise);
                         endTimestamp = System.currentTimeMillis();
                         this.updateFaultItem(mq.getBrokerName(), endTimestamp - beginTimestampPrev, false);
                         switch (communicationMode) {
@@ -582,7 +583,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         final CommunicationMode communicationMode, //
         final SendCallback sendCallback, //
         final TopicPublishInfo topicPublishInfo, //
-        final long timeout) throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
+        final long timeout, SendPromise promise) throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
         String brokerAddr = this.mQClientFactory.findBrokerAddressInPublish(mq.getBrokerName());
         if (null == brokerAddr) {
             tryToFindTopicPublishInfo(mq.getTopic());
@@ -680,7 +681,8 @@ public class DefaultMQProducerImpl implements MQProducerInner {
                             topicPublishInfo, // 8
                             this.mQClientFactory, // 9
                             this.defaultMQProducer.getRetryTimesWhenSendAsyncFailed(), // 10
-                            context, //
+                            context,
+                            promise,
                             this);
                         break;
                     case ONEWAY:
@@ -801,7 +803,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
      */
     public void sendOneway(Message msg) throws MQClientException, RemotingException, InterruptedException {
         try {
-            this.sendDefaultImpl(msg, CommunicationMode.ONEWAY, null, this.defaultMQProducer.getSendMsgTimeout());
+            this.sendDefaultImpl(msg, CommunicationMode.ONEWAY, null, this.defaultMQProducer.getSendMsgTimeout(), null);
         } catch (MQBrokerException e) {
             throw new MQClientException("unknown exception", e);
         }
@@ -824,7 +826,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
             throw new MQClientException("message's topic not equal mq's topic", null);
         }
 
-        return this.sendKernelImpl(msg, mq, CommunicationMode.SYNC, null, null, timeout);
+        return this.sendKernelImpl(msg, mq, CommunicationMode.SYNC, null, null, timeout, null);
     }
 
     /**
@@ -845,7 +847,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         }
 
         try {
-            this.sendKernelImpl(msg, mq, CommunicationMode.ASYNC, sendCallback, null, timeout);
+            this.sendKernelImpl(msg, mq, CommunicationMode.ASYNC, sendCallback, null, timeout, null);
         } catch (MQBrokerException e) {
             throw new MQClientException("unknown exception", e);
         }
@@ -859,7 +861,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
         Validators.checkMessage(msg, this.defaultMQProducer);
 
         try {
-            this.sendKernelImpl(msg, mq, CommunicationMode.ONEWAY, null, null, this.defaultMQProducer.getSendMsgTimeout());
+            this.sendKernelImpl(msg, mq, CommunicationMode.ONEWAY, null, null, this.defaultMQProducer.getSendMsgTimeout(), null);
         } catch (MQBrokerException e) {
             throw new MQClientException("unknown exception", e);
         }
@@ -898,7 +900,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
             }
 
             if (mq != null) {
-                return this.sendKernelImpl(msg, mq, communicationMode, sendCallback, null, timeout);
+                return this.sendKernelImpl(msg, mq, communicationMode, sendCallback, null, timeout, null);
             } else {
                 throw new MQClientException("select message queue return null.", null);
             }
@@ -1046,7 +1048,7 @@ public class DefaultMQProducerImpl implements MQProducerInner {
     }
 
     public SendResult send(Message msg, long timeout) throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
-        return this.sendDefaultImpl(msg, CommunicationMode.SYNC, null, timeout);
+        return this.sendDefaultImpl(msg, CommunicationMode.SYNC, null, timeout, null);
     }
 
     public ConcurrentHashMap<String, TopicPublishInfo> getTopicPublishInfoTable() {

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultSendPromise.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/DefaultSendPromise.java
@@ -1,0 +1,281 @@
+package org.apache.rocketmq.client.impl.producer;
+
+import org.apache.rocketmq.client.log.ClientLogger;
+import org.apache.rocketmq.client.producer.SendCallback;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendFuture;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * Created by stone
+ */
+public class DefaultSendPromise extends CountDownLatch implements SendPromise {
+
+    private final Logger logger = ClientLogger.getLog();
+
+    private Executor executor;
+    private Object callbacks;
+    private volatile Object result;
+
+    public DefaultSendPromise(Executor executor) {
+        super(1);
+
+        if (executor == null) {
+            throw new NullPointerException("executor");
+        }
+        if (executor instanceof ExecutorService) {
+            ExecutorService service = (ExecutorService) executor;
+            if (service.isShutdown() || service.isTerminated()) {
+                throw new IllegalArgumentException("terminated executor service");
+            }
+        }
+
+        this.executor = executor;
+    }
+
+    @Override
+    public SendPromise complete(SendResult result) {
+        if (result == null) {
+            throw new NullPointerException("result");
+        }
+
+        if (competeOnce(result)) {
+            invokeCallbacks();
+        }
+
+        return this;
+    }
+
+    public boolean competeOnce(Object result) {
+        if (isDone()) {
+            return false;
+        }
+
+        synchronized (this) {
+            if (isDone()) {
+                return false;
+            }
+
+            this.result = result;
+            countDown();
+        }
+
+        return true;
+    }
+
+    @Override
+    public SendPromise report(Throwable cause) {
+        if (cause == null) {
+            throw new NullPointerException("cause");
+        }
+
+        if (competeOnce(cause)) {
+            invokeCallbacks();
+        }
+
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public SendFuture addCallback(SendCallback callback) {
+        if (callback == null) {
+            throw new NullPointerException("listener");
+        }
+
+        if (isDone()) {
+            invoke(callback);
+            return this;
+        }
+
+        synchronized (this) {
+            if (!isDone()) {
+                if (callbacks == null) {
+                    callbacks = callback;
+                    return this;
+                }
+
+                List<SendCallback> callbacks;
+                if (this.callbacks instanceof List) {
+                    callbacks = (List<SendCallback>) this.callbacks;
+                    callbacks.add(callback);
+                } else {
+                    SendCallback previous = (SendCallback) this.callbacks;
+                    callbacks = new ArrayList<>();
+                    callbacks.add(previous);
+
+                    this.callbacks = callbacks;
+                }
+
+                callbacks.add(callback);
+                return this;
+            }
+        }
+
+        invoke(callback);
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public SendFuture removeCallback(SendCallback listener) {
+        if (listener == null) {
+            throw new NullPointerException("listener");
+        }
+
+        if (isDone()) {
+            return this;
+        }
+
+        synchronized (this) {
+            if (callbacks == null) {
+                return this;
+            }
+
+            if (callbacks == listener) {
+                callbacks = null;
+                return this;
+            }
+
+            List<SendCallback> listeners = (List<SendCallback>) this.callbacks;
+            listeners.remove(listener);
+        }
+
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void invokeCallbacks() {
+        if (callbacks == null) {
+            return ;
+        }
+
+        if (callbacks instanceof List) {
+            List<SendCallback> callbacks = (List<SendCallback>) this.callbacks;
+            for (SendCallback callback : callbacks) {
+                invoke(callback);
+            }
+        } else {
+            SendCallback callback = (SendCallback) this.callbacks;
+            invoke(callback);
+        }
+    }
+
+    public void invoke(final SendCallback callback) {
+        try {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    Object result = DefaultSendPromise.this.result;
+                    if (result instanceof Throwable) {
+                        callback.onException((Throwable) result);
+                    } else {
+                        callback.onSuccess((SendResult) result);
+                    }
+                }
+            });
+        } catch (Throwable cause) {
+            if (logger.isWarnEnabled()) {
+                logger.warn("invoke listener({}) error",  callback.getClass().getName(), cause);
+            }
+        }
+    }
+
+    @Override
+    public Throwable getCause() {
+        if (result instanceof Throwable) {
+            return (Throwable) result;
+        }
+        return null;
+    }
+
+    @Override
+    public final boolean cancel(boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public final boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return result != null;
+    }
+
+    public SendFuture waitUntil() {
+        if (isDone()) {
+            return this;
+        }
+
+        while (!isDone()) {
+            try {
+                await();
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+
+        return this;
+    }
+
+    public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
+        if (isDone()) {
+            return true;
+        }
+
+        if (timeout <= 0) {
+            return isDone();
+        }
+
+        await(timeout, unit);
+        return isDone();
+    }
+
+    @Override
+    public SendResult get() throws InterruptedException, ExecutionException {
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        }
+
+        waitUntil();
+
+        Throwable cause = getCause();
+        if (cause == null) {
+            if (!(result instanceof Throwable)) {
+                return (SendResult) result;
+            }
+
+            return null;
+        }
+
+        throw new ExecutionException(cause);
+    }
+
+    @Override
+    public SendResult get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (Thread.interrupted()) {
+            throw new InterruptedException();
+        }
+
+        if (waitFor(timeout, unit)) {
+            Throwable cause = getCause();
+            if (cause == null) {
+                if (!(result instanceof Throwable)) {
+                    return (SendResult) result;
+                }
+
+                return null;
+            }
+
+            throw new ExecutionException(cause);
+        }
+
+        throw new TimeoutException();
+    }
+}

--- a/client/src/main/java/org/apache/rocketmq/client/impl/producer/SendPromise.java
+++ b/client/src/main/java/org/apache/rocketmq/client/impl/producer/SendPromise.java
@@ -1,0 +1,11 @@
+package org.apache.rocketmq.client.impl.producer;
+
+import org.apache.rocketmq.client.producer.SendFuture;
+import org.apache.rocketmq.client.producer.SendResult;
+
+public interface SendPromise extends SendFuture {
+
+    SendPromise complete(SendResult result);
+    SendPromise report(Throwable cause);
+
+}

--- a/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/DefaultMQProducer.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.client.producer;
 
 import java.util.List;
+import java.util.concurrent.Executor;
+
 import org.apache.rocketmq.client.ClientConfig;
 import org.apache.rocketmq.client.QueryResult;
 import org.apache.rocketmq.client.exception.MQBrokerException;
@@ -98,6 +100,11 @@ public class DefaultMQProducer extends ClientConfig implements MQProducer {
     public void send(Message msg, SendCallback sendCallback, long timeout)
         throws MQClientException, RemotingException, InterruptedException {
         this.defaultMQProducerImpl.send(msg, sendCallback, timeout);
+    }
+
+    @Override
+    public SendFuture send(Message message, Executor executor, long timeout) throws MQClientException, RemotingException {
+        return defaultMQProducerImpl.send(message, executor, timeout);
     }
 
     @Override

--- a/client/src/main/java/org/apache/rocketmq/client/producer/MQProducer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/MQProducer.java
@@ -17,6 +17,8 @@
 package org.apache.rocketmq.client.producer;
 
 import java.util.List;
+import java.util.concurrent.Executor;
+
 import org.apache.rocketmq.client.MQAdmin;
 import org.apache.rocketmq.client.exception.MQBrokerException;
 import org.apache.rocketmq.client.exception.MQClientException;
@@ -42,6 +44,8 @@ public interface MQProducer extends MQAdmin {
 
     void send(final Message msg, final SendCallback sendCallback, final long timeout)
         throws MQClientException, RemotingException, InterruptedException;
+
+    SendFuture send(Message message, Executor executor, long timeout) throws MQClientException, RemotingException, InterruptedException;
 
     void sendOneway(final Message msg) throws MQClientException, RemotingException,
         InterruptedException;

--- a/client/src/main/java/org/apache/rocketmq/client/producer/SendFuture.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/SendFuture.java
@@ -1,0 +1,21 @@
+package org.apache.rocketmq.client.producer;
+
+import java.util.concurrent.Future;
+
+public interface SendFuture extends Future<SendResult> {
+
+    /**
+     * Returns the cause resulting in sending error
+     */
+    Throwable getCause();
+
+    /**
+     * Returns {@code true} if this task completed.
+     */
+    @Override
+    boolean isDone();
+
+    SendFuture addCallback(SendCallback callback);
+    SendFuture removeCallback(SendCallback callback);
+
+}

--- a/client/src/test/java/org/apache/rocketmq/client/TestSendPromise.java
+++ b/client/src/test/java/org/apache/rocketmq/client/TestSendPromise.java
@@ -1,0 +1,65 @@
+package org.apache.rocketmq.client;
+
+import org.apache.rocketmq.client.impl.producer.DefaultSendPromise;
+import org.apache.rocketmq.client.producer.SendCallback;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+public class TestSendPromise {
+
+    @Test
+    public void testBasicOperations() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+
+        DefaultSendPromise promise = new DefaultSendPromise(executor);
+
+        final CountDownLatch latch = new CountDownLatch(2);
+        final CountDownLatch latch1 = new CountDownLatch(2);
+        SendCallback callback = new SendCallback() {
+            @Override
+            public void onSuccess(SendResult sendResult) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                latch1.countDown();
+            }
+        };
+        SendCallback callback2 = new SendCallback() {
+            @Override
+            public void onSuccess(SendResult sendResult) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onException(Throwable e) {
+                latch1.countDown();
+            }
+        };
+        promise.addCallback(callback).addCallback(callback2);
+
+        SendResult result = new SendResult();
+        promise.complete(result);
+        Assert.assertTrue(latch.await(5000, TimeUnit.MILLISECONDS));
+        Assert.assertEquals(promise.get(), result);
+        Assert.assertEquals(promise.get(1, TimeUnit.SECONDS), result);
+
+        DefaultSendPromise promise1 = new DefaultSendPromise(executor);
+        Exception cause = new Exception();
+        promise1.report(cause);
+        promise1.addCallback(callback).addCallback(callback2);
+
+        Assert.assertEquals(cause, promise1.getCause());
+
+        Assert.assertTrue(latch1.await(5000, TimeUnit.MILLISECONDS));
+
+        executor.shutdown();
+    }
+}


### PR DESCRIPTION
an new way to send message in async way, it looks like:

```
MQProducer producer = ...;
ExecutorService sharedExecutorService = ...
SendFuture future = producer.send(msg, sharedExecutorService, timeout);
future.addCallback(new SendCallback() {
            @Override
            public void onSuccess(SendResult sendResult) {
                  // do sth 
            }

            @Override
            public void onException(Throwable e) {
                   // do sth
            }
})
```

There are three advantages for this way:

0. Executes the callback logic in exclusive thread pool
1. Multiple callbacks are allowed 
2. Gets the result of sending in synchronous API(get/get(time, unit))