### PR TITLE
[ROCKETMQ-43] Remove NoWhitespaceBefore module in “rmq_checkstyle.xml”

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/BrokerStartup.java
@@ -64,7 +64,8 @@ public class BrokerStartup {
 
             log.info(tip);
             return controller;
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             e.printStackTrace();
             System.exit(-1);
         }
@@ -109,7 +110,8 @@ public class BrokerStartup {
                 MixAll.printObjectProperties(null, nettyClientConfig);
                 MixAll.printObjectProperties(null, messageStoreConfig);
                 System.exit(0);
-            } else if (commandLine.hasOption('m')) {
+            }
+            else if (commandLine.hasOption('m')) {
                 MixAll.printObjectProperties(null, brokerConfig, true);
                 MixAll.printObjectProperties(null, nettyServerConfig, true);
                 MixAll.printObjectProperties(null, nettyClientConfig, true);
@@ -151,7 +153,8 @@ public class BrokerStartup {
                     for (String addr : addrArray) {
                         RemotingUtil.string2SocketAddress(addr);
                     }
-                } catch (Exception e) {
+                }
+                catch (Exception e) {
                     System.out.printf(
                         "The Name Server Address[%s] illegal, please set it as follows, \"127.0.0.1:9876;192.168.0.1:9876\"%n",
                         namesrvAddr);
@@ -176,7 +179,7 @@ public class BrokerStartup {
             }
 
             messageStoreConfig.setHaListenPort(nettyServerConfig.getListenPort() + 1);
-            LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+            LoggerContext lc = (LoggerContext)LoggerFactory.getILoggerFactory();
             JoranConfigurator configurator = new JoranConfigurator();
             configurator.setContext(lc);
             lc.reset();
@@ -222,7 +225,8 @@ public class BrokerStartup {
             }, "ShutdownHook"));
 
             return controller;
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             e.printStackTrace();
             System.exit(-1);
         }

--- a/filtersrv/src/main/java/org/apache/rocketmq/filtersrv/FiltersrvStartup.java
+++ b/filtersrv/src/main/java/org/apache/rocketmq/filtersrv/FiltersrvStartup.java
@@ -48,7 +48,8 @@ public class FiltersrvStartup {
 
         try {
             controller.start();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
             System.exit(-1);
         }
@@ -120,7 +121,7 @@ public class FiltersrvStartup {
                 System.exit(-2);
             }
 
-            LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+            LoggerContext lc = (LoggerContext)LoggerFactory.getILoggerFactory();
             JoranConfigurator configurator = new JoranConfigurator();
             configurator.setContext(lc);
             lc.reset();
@@ -155,7 +156,8 @@ public class FiltersrvStartup {
             }, "ShutdownHook"));
 
             return controller;
-        } catch (Throwable e) {
+        }
+        catch (Throwable e) {
             e.printStackTrace();
             System.exit(-1);
         }

--- a/style/rmq_checkstyle.xml
+++ b/style/rmq_checkstyle.xml
@@ -121,7 +121,6 @@
         <!--whitespace-->
         <module name="GenericWhitespace"/>
         <module name="NoWhitespaceBefore"/>
-        <module name="WhitespaceAfter"/>
         <module name="NoWhitespaceAfter"/>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>

--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
@@ -100,7 +100,8 @@ public class MQAdminStartup {
                             if (options != null) {
                                 ServerUtil.printCommandLineHelp("mqadmin " + cmd.commandName(), options);
                             }
-                        } else {
+                        }
+                        else {
                             System.out.printf("The sub command \'" + args[1] + "\' not exist.%n");
                         }
                         break;
@@ -126,12 +127,14 @@ public class MQAdminStartup {
                         }
 
                         cmd.execute(commandLine, options, rpcHook);
-                    } else {
+                    }
+                    else {
                         System.out.printf("The sub command \'" + args[0] + "\' not exist.%n");
                     }
                     break;
             }
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             e.printStackTrace();
         }
     }
@@ -194,7 +197,7 @@ public class MQAdminStartup {
     private static void initLogback() throws JoranException {
         String rocketmqHome = System.getProperty(MixAll.ROCKETMQ_HOME_PROPERTY, System.getenv(MixAll.ROCKETMQ_HOME_ENV));
 
-        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        LoggerContext lc = (LoggerContext)LoggerFactory.getILoggerFactory();
         JoranConfigurator configurator = new JoranConfigurator();
         configurator.setContext(lc);
         lc.reset();


### PR DESCRIPTION
There are both NoWhitespaceBefore and WhitespaceAfter modules in checkstyle.xml, like this:
<module name="NoWhitespaceBefore"/>
<module name="WhitespaceAfter"/>

ref https://issues.apache.org/jira/browse/ROCKETMQ-43