### PR TITLE
[ROCKETMQ-38] Some unit tests for rocketmq-remoting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.6.1</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -462,7 +462,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.6.1</version>
+                <version>2.6.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/remoting/pom.xml
+++ b/remoting/pom.xml
@@ -36,6 +36,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
         </dependency>

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
@@ -184,7 +184,6 @@ public class RemotingCommandTest {
 class SampleCommandCustomHeader implements CommandCustomHeader {
     @Override
     public void checkFields() throws RemotingCommandException {
-        return;
     }
 }
 

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.protocol;
+
+import org.apache.rocketmq.remoting.CommandCustomHeader;
+import org.apache.rocketmq.remoting.exception.RemotingCommandException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RemotingCommandTest {
+    @Test
+    public void testCreateRequestCommand() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        int code = 103; //org.apache.rocketmq.common.protocol.RequestCode.REGISTER_BROKER
+        CommandCustomHeader header = new SampleCommandCustomHeader();
+        RemotingCommand cmd = RemotingCommand.createRequestCommand(code, header);
+        Assert.assertEquals(code, cmd.getCode());
+        Assert.assertEquals(2333, cmd.getVersion());
+        Assert.assertEquals(0, cmd.getFlag() & 0x01); //flag bit 0: 0 presents request
+    }
+
+    @Test
+    public void testCreateResponseCommandSuccess() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        int code = RemotingSysResponseCode.SUCCESS;
+        String remark = "Sample remark";
+        RemotingCommand cmd = RemotingCommand.createResponseCommand(code ,remark, SampleCommandCustomHeader.class);
+        Assert.assertEquals(code, cmd.getCode());
+        Assert.assertEquals(2333, cmd.getVersion());
+        Assert.assertEquals(remark, cmd.getRemark());
+        Assert.assertEquals(1, cmd.getFlag() & 0x01); //flag bit 0: 1 presents response
+    }
+
+    @Test
+    public void testCreateResponseCommandWithNoHeader() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        int code = RemotingSysResponseCode.SUCCESS;
+        String remark = "Sample remark";
+        RemotingCommand cmd = RemotingCommand.createResponseCommand(code ,remark);
+        Assert.assertEquals(code, cmd.getCode());
+        Assert.assertEquals(2333, cmd.getVersion());
+        Assert.assertEquals(remark, cmd.getRemark());
+        Assert.assertEquals(1, cmd.getFlag() & 0x01); //flag bit 0: 1 presents response
+    }
+
+    @Test
+    public void testCreateResponseCommandNull() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        int code = RemotingSysResponseCode.SUCCESS;
+        String remark = "Sample remark";
+        RemotingCommand cmd = RemotingCommand.createResponseCommand(code ,remark, CommandCustomHeader.class);
+        Assert.assertNull(cmd);
+    }
+
+    @Test
+    public void testCreateResponseCommandError() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        RemotingCommand cmd = RemotingCommand.createResponseCommand(SampleCommandCustomHeader.class);
+        Assert.assertEquals(RemotingSysResponseCode.SYSTEM_ERROR, cmd.getCode());
+        Assert.assertEquals(2333, cmd.getVersion());
+        Assert.assertEquals("not set any response code", cmd.getRemark());
+        Assert.assertEquals(1, cmd.getFlag() & 0x01); //flag bit 0: 1 presents response
+    }
+
+    @Test
+    public void testMarkProtocolTypeForJSON() {
+        int source = 261;
+        SerializeType type = SerializeType.JSON;
+        byte[] result = RemotingCommand.markProtocolType(source, type);
+        Assert.assertArrayEquals(new byte[]{0, 0, 1, 5}, result);
+    }
+
+    @Test
+    public void testMarkProtocolTypeForROCKETMQ() {
+        int source = 16777215;
+        SerializeType type = SerializeType.ROCKETMQ;
+        byte[] result = RemotingCommand.markProtocolType(source, type);
+        Assert.assertArrayEquals(new byte[]{1, -1, -1, -1}, result);
+    }
+
+}
+
+class SampleCommandCustomHeader implements CommandCustomHeader {
+    @Override
+    public void checkFields() throws RemotingCommandException {
+        return;
+    }
+}

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingCommandTest.java
@@ -62,7 +62,7 @@ public class RemotingCommandTest {
         assertThat(cmd.getCode()).isEqualTo(code);
         assertThat(cmd.getVersion()).isEqualTo(2333);
         assertThat(cmd.getRemark()).isEqualTo(remark);
-        assertThat(cmd.getFlag() & 0x01).isEqualTo(1); //flag bit 0: 1 presents request
+        assertThat(cmd.getFlag() & 0x01).isEqualTo(1); //flag bit 0: 1 presents response
     }
 
     @Test
@@ -75,7 +75,7 @@ public class RemotingCommandTest {
         assertThat(cmd.getCode()).isEqualTo(code);
         assertThat(cmd.getVersion()).isEqualTo(2333);
         assertThat(cmd.getRemark()).isEqualTo(remark);
-        assertThat(cmd.getFlag() & 0x01).isEqualTo(1); //flag bit 0: 1 presents request
+        assertThat(cmd.getFlag() & 0x01).isEqualTo(1); //flag bit 0: 1 presents response
     }
 
     @Test
@@ -145,7 +145,7 @@ public class RemotingCommandTest {
     }
 
     @Test
-    public void testEncodeAndDecode_FilledBodyWithExtFields() {
+    public void testEncodeAndDecode_FilledBodyWithExtFields() throws RemotingCommandException {
         System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
 
         int code = 103; //org.apache.rocketmq.common.protocol.RequestCode.REGISTER_BROKER
@@ -172,17 +172,12 @@ public class RemotingCommandTest {
 
         assertThat(decodedCommand.getExtFields().get("key")).isEqualTo("value");
 
-        try {
-            CommandCustomHeader decodedHeader = decodedCommand.decodeCommandCustomHeader(ExtFieldsHeader.class);
-            assertThat(((ExtFieldsHeader)decodedHeader).getStringValue()).isEqualTo("bilibili");
-            assertThat(((ExtFieldsHeader)decodedHeader).getIntValue()).isEqualTo(2333);
-            assertThat(((ExtFieldsHeader)decodedHeader).getLongValue()).isEqualTo(23333333l);
-            assertThat(((ExtFieldsHeader)decodedHeader).isBooleanValue()).isEqualTo(true);
-            assertThat(((ExtFieldsHeader)decodedHeader).getDoubleValue()).isBetween(0.617, 0.619);
-
-        } catch (RemotingCommandException ex) {
-            fail(ex.getMessage());
-        }
+        CommandCustomHeader decodedHeader = decodedCommand.decodeCommandCustomHeader(ExtFieldsHeader.class);
+        assertThat(((ExtFieldsHeader) decodedHeader).getStringValue()).isEqualTo("bilibili");
+        assertThat(((ExtFieldsHeader) decodedHeader).getIntValue()).isEqualTo(2333);
+        assertThat(((ExtFieldsHeader) decodedHeader).getLongValue()).isEqualTo(23333333l);
+        assertThat(((ExtFieldsHeader) decodedHeader).isBooleanValue()).isEqualTo(true);
+        assertThat(((ExtFieldsHeader) decodedHeader).getDoubleValue()).isBetween(0.617, 0.619);
     }
 }
 

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RemotingSerializableTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.protocol;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class RemotingSerializableTest {
+    @Test
+    public void testEncodeAndDecode_HeterogeneousClass() {
+        Sample sample = new Sample();
+
+        byte[] bytes = RemotingSerializable.encode(sample);
+        Sample decodedSample = RemotingSerializable.decode(bytes, Sample.class);
+
+        assertThat(decodedSample).isEqualTo(sample);
+    }
+
+    @Test
+    public void testToJson_normalString() {
+        RemotingSerializable serializable = new RemotingSerializable() {
+            private List<String> stringList = Arrays.asList("a", "o", "e", "i", "u", "v");
+
+            public List<String> getStringList() {
+                return stringList;
+            }
+
+            public void setStringList(List<String> stringList) {
+                this.stringList = stringList;
+            }
+        };
+
+        String string = serializable.toJson();
+
+        assertThat(string).isEqualTo("{\"stringList\":[\"a\",\"o\",\"e\",\"i\",\"u\",\"v\"]}");
+    }
+
+    @Test
+    public void testToJson_prettyString() {
+        RemotingSerializable serializable = new RemotingSerializable() {
+            private List<String> stringList = Arrays.asList("a", "o", "e", "i", "u", "v");
+
+            public List<String> getStringList() {
+                return stringList;
+            }
+
+            public void setStringList(List<String> stringList) {
+                this.stringList = stringList;
+            }
+        };
+
+        String prettyString = serializable.toJson(true);
+
+        assertThat(prettyString).isEqualTo("{\n" +
+            "\t\"stringList\":[\n" +
+            "\t\t\"a\",\n" +
+            "\t\t\"o\",\n" +
+            "\t\t\"e\",\n" +
+            "\t\t\"i\",\n" +
+            "\t\t\"u\",\n" +
+            "\t\t\"v\"\n" +
+            "\t]\n" +
+            "}");
+    }
+
+}
+
+class Sample {
+    private String stringValue = "string";
+    private int intValue = 2333;
+    private Integer integerValue = 666;
+    private double[] doubleArray = new double[]{0.618, 1.618};
+    private List<String> stringList = Arrays.asList("a", "o", "e", "i", "u", "v");
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    public int getIntValue() {
+        return intValue;
+    }
+
+    public void setIntValue(int intValue) {
+        this.intValue = intValue;
+    }
+
+    public Integer getIntegerValue() {
+        return integerValue;
+    }
+
+    public void setIntegerValue(Integer integerValue) {
+        this.integerValue = integerValue;
+    }
+
+    public double[] getDoubleArray() {
+        return doubleArray;
+    }
+
+    public void setDoubleArray(double[] doubleArray) {
+        this.doubleArray = doubleArray;
+    }
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(List<String> stringList) {
+        this.stringList = stringList;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        Sample sample = (Sample)o;
+
+        if (intValue != sample.intValue)
+            return false;
+        if (stringValue != null ? !stringValue.equals(sample.stringValue) : sample.stringValue != null)
+            return false;
+        if (integerValue != null ? !integerValue.equals(sample.integerValue) : sample.integerValue != null)
+            return false;
+        if (!Arrays.equals(doubleArray, sample.doubleArray))
+            return false;
+        return stringList != null ? stringList.equals(sample.stringList) : sample.stringList == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = stringValue != null ? stringValue.hashCode() : 0;
+        result = 31 * result + intValue;
+        result = 31 * result + (integerValue != null ? integerValue.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(doubleArray);
+        result = 31 * result + (stringList != null ? stringList.hashCode() : 0);
+        return result;
+    }
+}

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializableTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.remoting.protocol;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class RocketMQSerializableTest {
+    @Test
+    public void testRocketMQProtocolEncodeAndDecode_WithoutRemarkWithoutExtFields() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        int code = 103; //org.apache.rocketmq.common.protocol.RequestCode.REGISTER_BROKER
+        RemotingCommand cmd = RemotingCommand.createRequestCommand(code,
+            new SampleCommandCustomHeader());
+        cmd.setSerializeTypeCurrentRPC(SerializeType.ROCKETMQ);
+
+        byte[] result = RocketMQSerializable.rocketMQProtocolEncode(cmd);
+
+        assertThat(result).hasSize(21);
+        assertThat(parseToShort(result, 0)).isEqualTo((short) code); //code
+        assertThat(result[2]).isEqualTo(LanguageCode.JAVA.getCode()); //language
+        assertThat(parseToShort(result, 3)).isEqualTo((short) 2333); //version
+        assertThat(parseToInt(result, 5)).isEqualTo(cmd.getOpaque()); //opaque
+        assertThat(parseToInt(result, 9)).isEqualTo(0); //flag
+        assertThat(parseToInt(result, 13)).isEqualTo(0); //empty remark
+        assertThat(parseToInt(result, 17)).isEqualTo(0); //empty extFields
+
+        RemotingCommand decodedCommand = RocketMQSerializable.rocketMQProtocolDecode(result);
+
+        assertThat(decodedCommand.getCode()).isEqualTo(code);
+        assertThat(decodedCommand.getLanguage()).isEqualTo(LanguageCode.JAVA);
+        assertThat(decodedCommand.getVersion()).isEqualTo(2333);
+        assertThat(decodedCommand.getOpaque()).isEqualTo(cmd.getOpaque());
+        assertThat(decodedCommand.getFlag()).isEqualTo(0);
+        assertThat(decodedCommand.getRemark()).isNull();
+        assertThat(decodedCommand.getExtFields()).isNull();
+    }
+
+    @Test
+    public void testRocketMQProtocolEncodeAndDecode_WithRemarkWithoutExtFields() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        int code = 103; //org.apache.rocketmq.common.protocol.RequestCode.REGISTER_BROKER
+        RemotingCommand cmd = RemotingCommand.createRequestCommand(code,
+            new SampleCommandCustomHeader());
+        cmd.setSerializeTypeCurrentRPC(SerializeType.ROCKETMQ);
+        cmd.setRemark("Sample Remark");
+
+        byte[] result = RocketMQSerializable.rocketMQProtocolEncode(cmd);
+
+        assertThat(result).hasSize(34);
+        assertThat(parseToShort(result, 0)).isEqualTo((short) code); //code
+        assertThat(result[2]).isEqualTo(LanguageCode.JAVA.getCode()); //language
+        assertThat(parseToShort(result, 3)).isEqualTo((short) 2333); //version
+        assertThat(parseToInt(result, 5)).isEqualTo(cmd.getOpaque()); //opaque
+        assertThat(parseToInt(result, 9)).isEqualTo(0); //flag
+        assertThat(parseToInt(result, 13)).isEqualTo(13); //remark length
+
+        byte[] remarkArray = new byte[13];
+        System.arraycopy(result, 17, remarkArray, 0, 13);
+        assertThat(new String(remarkArray)).isEqualTo("Sample Remark");
+
+        assertThat(parseToInt(result, 30)).isEqualTo(0); //empty extFields
+
+        RemotingCommand decodedCommand = RocketMQSerializable.rocketMQProtocolDecode(result);
+
+        assertThat(decodedCommand.getCode()).isEqualTo(code);
+        assertThat(decodedCommand.getLanguage()).isEqualTo(LanguageCode.JAVA);
+        assertThat(decodedCommand.getVersion()).isEqualTo(2333);
+        assertThat(decodedCommand.getOpaque()).isEqualTo(cmd.getOpaque());
+        assertThat(decodedCommand.getFlag()).isEqualTo(0);
+        assertThat(decodedCommand.getRemark()).contains("Sample Remark");
+        assertThat(decodedCommand.getExtFields()).isNull();
+    }
+
+    @Test
+    public void testRocketMQProtocolEncodeAndDecode_WithoutRemarkWithExtFields() {
+        System.setProperty(RemotingCommand.REMOTING_VERSION_KEY, "2333");
+
+        int code = 103; //org.apache.rocketmq.common.protocol.RequestCode.REGISTER_BROKER
+        RemotingCommand cmd = RemotingCommand.createRequestCommand(code,
+            new SampleCommandCustomHeader());
+        cmd.setSerializeTypeCurrentRPC(SerializeType.ROCKETMQ);
+        cmd.addExtField("key", "value");
+
+        byte[] result = RocketMQSerializable.rocketMQProtocolEncode(cmd);
+
+        assertThat(result).hasSize(35);
+        assertThat(parseToShort(result, 0)).isEqualTo((short) code); //code
+        assertThat(result[2]).isEqualTo(LanguageCode.JAVA.getCode()); //language
+        assertThat(parseToShort(result, 3)).isEqualTo((short) 2333); //version
+        assertThat(parseToInt(result, 5)).isEqualTo(cmd.getOpaque()); //opaque
+        assertThat(parseToInt(result, 9)).isEqualTo(0); //flag
+        assertThat(parseToInt(result, 13)).isEqualTo(0); //empty remark
+        assertThat(parseToInt(result, 17)).isEqualTo(14); //extFields length
+
+        byte[] extFieldsArray = new byte[14];
+        System.arraycopy(result, 21, extFieldsArray, 0, 14);
+        HashMap<String, String> extFields = RocketMQSerializable.mapDeserialize(extFieldsArray);
+        assertThat(extFields).contains(new HashMap.SimpleEntry("key", "value"));
+
+        RemotingCommand decodedCommand = RocketMQSerializable.rocketMQProtocolDecode(result);
+
+        assertThat(decodedCommand.getCode()).isEqualTo(code);
+        assertThat(decodedCommand.getLanguage()).isEqualTo(LanguageCode.JAVA);
+        assertThat(decodedCommand.getVersion()).isEqualTo(2333);
+        assertThat(decodedCommand.getOpaque()).isEqualTo(cmd.getOpaque());
+        assertThat(decodedCommand.getFlag()).isEqualTo(0);
+        assertThat(decodedCommand.getRemark()).isNull();
+        assertThat(decodedCommand.getExtFields()).contains(new HashMap.SimpleEntry("key", "value"));
+    }
+
+    private short parseToShort(byte[] array, int index) {
+        return (short) (array[index] * 256 + array[++index]);
+    }
+
+    private int parseToInt(byte[] array, int index) {
+        return array[index] * 16777216 + array[++index] * 65536 + array[++index] * 256
+               + array[++index];
+    }
+}

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializableTest.java
@@ -32,12 +32,12 @@ public class RocketMQSerializableTest {
         cmd.setSerializeTypeCurrentRPC(SerializeType.ROCKETMQ);
 
         byte[] result = RocketMQSerializable.rocketMQProtocolEncode(cmd);
+        int opaque = cmd.getOpaque();
 
         assertThat(result).hasSize(21);
         assertThat(parseToShort(result, 0)).isEqualTo((short) code); //code
         assertThat(result[2]).isEqualTo(LanguageCode.JAVA.getCode()); //language
         assertThat(parseToShort(result, 3)).isEqualTo((short) 2333); //version
-        assertThat(parseToInt(result, 5)).isEqualTo(cmd.getOpaque()); //opaque
         assertThat(parseToInt(result, 9)).isEqualTo(0); //flag
         assertThat(parseToInt(result, 13)).isEqualTo(0); //empty remark
         assertThat(parseToInt(result, 17)).isEqualTo(0); //empty extFields
@@ -47,7 +47,7 @@ public class RocketMQSerializableTest {
         assertThat(decodedCommand.getCode()).isEqualTo(code);
         assertThat(decodedCommand.getLanguage()).isEqualTo(LanguageCode.JAVA);
         assertThat(decodedCommand.getVersion()).isEqualTo(2333);
-        assertThat(decodedCommand.getOpaque()).isEqualTo(cmd.getOpaque());
+        assertThat(decodedCommand.getOpaque()).isEqualTo(opaque);
         assertThat(decodedCommand.getFlag()).isEqualTo(0);
         assertThat(decodedCommand.getRemark()).isNull();
         assertThat(decodedCommand.getExtFields()).isNull();
@@ -64,12 +64,12 @@ public class RocketMQSerializableTest {
         cmd.setRemark("Sample Remark");
 
         byte[] result = RocketMQSerializable.rocketMQProtocolEncode(cmd);
+        int opaque = cmd.getOpaque();
 
         assertThat(result).hasSize(34);
         assertThat(parseToShort(result, 0)).isEqualTo((short) code); //code
         assertThat(result[2]).isEqualTo(LanguageCode.JAVA.getCode()); //language
         assertThat(parseToShort(result, 3)).isEqualTo((short) 2333); //version
-        assertThat(parseToInt(result, 5)).isEqualTo(cmd.getOpaque()); //opaque
         assertThat(parseToInt(result, 9)).isEqualTo(0); //flag
         assertThat(parseToInt(result, 13)).isEqualTo(13); //remark length
 
@@ -84,7 +84,7 @@ public class RocketMQSerializableTest {
         assertThat(decodedCommand.getCode()).isEqualTo(code);
         assertThat(decodedCommand.getLanguage()).isEqualTo(LanguageCode.JAVA);
         assertThat(decodedCommand.getVersion()).isEqualTo(2333);
-        assertThat(decodedCommand.getOpaque()).isEqualTo(cmd.getOpaque());
+        assertThat(decodedCommand.getOpaque()).isEqualTo(opaque);
         assertThat(decodedCommand.getFlag()).isEqualTo(0);
         assertThat(decodedCommand.getRemark()).contains("Sample Remark");
         assertThat(decodedCommand.getExtFields()).isNull();
@@ -101,12 +101,12 @@ public class RocketMQSerializableTest {
         cmd.addExtField("key", "value");
 
         byte[] result = RocketMQSerializable.rocketMQProtocolEncode(cmd);
+        int opaque = cmd.getOpaque();
 
         assertThat(result).hasSize(35);
         assertThat(parseToShort(result, 0)).isEqualTo((short) code); //code
         assertThat(result[2]).isEqualTo(LanguageCode.JAVA.getCode()); //language
         assertThat(parseToShort(result, 3)).isEqualTo((short) 2333); //version
-        assertThat(parseToInt(result, 5)).isEqualTo(cmd.getOpaque()); //opaque
         assertThat(parseToInt(result, 9)).isEqualTo(0); //flag
         assertThat(parseToInt(result, 13)).isEqualTo(0); //empty remark
         assertThat(parseToInt(result, 17)).isEqualTo(14); //extFields length
@@ -121,7 +121,7 @@ public class RocketMQSerializableTest {
         assertThat(decodedCommand.getCode()).isEqualTo(code);
         assertThat(decodedCommand.getLanguage()).isEqualTo(LanguageCode.JAVA);
         assertThat(decodedCommand.getVersion()).isEqualTo(2333);
-        assertThat(decodedCommand.getOpaque()).isEqualTo(cmd.getOpaque());
+        assertThat(decodedCommand.getOpaque()).isEqualTo(opaque);
         assertThat(decodedCommand.getFlag()).isEqualTo(0);
         assertThat(decodedCommand.getRemark()).isNull();
         assertThat(decodedCommand.getExtFields()).contains(new HashMap.SimpleEntry("key", "value"));

--- a/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializableTest.java
+++ b/remoting/src/test/java/org/apache/rocketmq/remoting/protocol/RocketMQSerializableTest.java
@@ -19,7 +19,6 @@ package org.apache.rocketmq.remoting.protocol;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.HashMap;
-import java.util.Map;
 import org.junit.Test;
 
 public class RocketMQSerializableTest {
@@ -126,6 +125,19 @@ public class RocketMQSerializableTest {
         assertThat(decodedCommand.getFlag()).isEqualTo(0);
         assertThat(decodedCommand.getRemark()).isNull();
         assertThat(decodedCommand.getExtFields()).contains(new HashMap.SimpleEntry("key", "value"));
+    }
+
+    @Test
+    public void testIsBlank_NotBlank() {
+        assertThat(RocketMQSerializable.isBlank("aeiou")).isFalse();
+        assertThat(RocketMQSerializable.isBlank("  A  ")).isFalse();
+    }
+
+    @Test
+    public void testIsBlank_Blank() {
+        assertThat(RocketMQSerializable.isBlank(null)).isTrue();
+        assertThat(RocketMQSerializable.isBlank("")).isTrue();
+        assertThat(RocketMQSerializable.isBlank("  ")).isTrue();
     }
 
     private short parseToShort(byte[] array, int index) {


### PR DESCRIPTION
[ref issue](https://issues.apache.org/jira/browse/ROCKETMQ-38).

I wish to improve unit test coverage for RocketMQ and wrote these **sample** tests following @vongosling 's guidance. 

> 1. Using testMethod_Condition naming conversion,
Because it's more friendly for maven surefire and idea moreunit plugin
> 2. Mock the module's interaction parts. 
We can use mockito tool to do this
> 3. More assert instead of simple printting. 
Recommend to use assert4j tool
> 4. Do not throw exception in test method
> 5. Use latch instead of thead.sleep
> 6. Pay more attention for your test time-consuming

@vongosling , @zhouxinyu , Would you mind review these **sample** test code to see whether the code style is suitable? Peg for suggestion. If that's OK, The remaining part would be finished just like the sample test code.