### PR TITLE
[ROCKETMQ-64] Remove duplication code line in BrokerOuterAPI.registerBroker method

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/out/BrokerOuterAPI.java
@@ -173,7 +173,6 @@ public class BrokerOuterAPI {
                 RegisterBrokerResult result = new RegisterBrokerResult();
                 result.setMasterAddr(responseHeader.getMasterAddr());
                 result.setHaServerAddr(responseHeader.getHaServerAddr());
-                result.setHaServerAddr(responseHeader.getHaServerAddr());
                 if (response.getBody() != null) {
                     result.setKvTable(KVTable.decode(response.getBody(), KVTable.class));
                 }


### PR DESCRIPTION
Remove duplicated 'result.setHaServerAddr(responseHeader.getHaServerAddr());' in  BrokerOuterAPI.registerBroker method