### PR TITLE
[ROCKETMQ-91] Reduce lock granularity for putMessage to get better performance

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/MessageExtBrokerInner.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MessageExtBrokerInner.java
@@ -16,6 +16,7 @@
  */
 package org.apache.rocketmq.store;
 
+import java.nio.ByteBuffer;
 import org.apache.rocketmq.common.TopicFilterType;
 import org.apache.rocketmq.common.message.MessageExt;
 
@@ -23,6 +24,8 @@ public class MessageExtBrokerInner extends MessageExt {
     private static final long serialVersionUID = 7256001576878700634L;
     private String propertiesString;
     private long tagsCode;
+
+    private ByteBuffer encodedBuffer;
 
     public static long tagsString2tagsCode(final TopicFilterType filter, final String tags) {
         if (null == tags || tags.length() == 0)
@@ -45,5 +48,13 @@ public class MessageExtBrokerInner extends MessageExt {
 
     public void setTagsCode(long tagsCode) {
         this.tagsCode = tagsCode;
+    }
+
+    public ByteBuffer getEncodedBuffer() {
+        return encodedBuffer;
+    }
+
+    public void setEncodedBuffer(ByteBuffer encodedBuffer) {
+        this.encodedBuffer = encodedBuffer;
     }
 }


### PR DESCRIPTION
## Motivation
CommitLog putMessage has a lock as:
```
lockForPutMessage()
try {
  .....
} finally {
releasePutMessageLock()
}
```
The logic inside the lock includes two main operations:
1 encode the message
2 write to the PageCache.
However, we can take the first operation(encode message) out from the lock to achieve better performance.

## Tests
### Env
> Linux 24 Core 48G SSD
> set sendMessageThreadPoolNums=5
> use five async Producers to do stress.
> 50Byte message，send one by one
### Results
reduce before: about **14w TPS**
reduce after: about **16w TPS**
And if we annotate the store layer, only test the network performance, we got about **17W TPS**.

The bottleneck now is in the network layer.

@zhouxinyu @vongosling @shroman please have a review.