### PR TITLE
HOTFIX: add a newline after help info

### DIFF
--- a/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
+++ b/tools/src/main/java/org/apache/rocketmq/tools/command/MQAdminStartup.java
@@ -208,7 +208,7 @@ public class MQAdminStartup {
             System.out.printf("   %-20s %s%n", cmd.commandName(), cmd.commandDesc());
         }
 
-        System.out.printf("%nSee 'mqadmin help <command>' for more information on a specific command.");
+        System.out.printf("%nSee 'mqadmin help <command>' for more information on a specific command.%n");
     }
 
     private static SubCommand findSubCommand(final String name) {


### PR DESCRIPTION
This is a very minor change. After execute command `sh mqadmin`, I get the last line info:
`See 'mqadmin help <command>' for more information on a specific command.[xinwang@hadoop bin]$`

Maybe we can improve this by adding a newline.