### PR TITLE
[ROCKETMQ-140]Guard MQVesion methods.

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MQVersion.java
@@ -21,16 +21,20 @@ public class MQVersion {
     public static final int CURRENT_VERSION = Version.V4_1_0_SNAPSHOT.ordinal();
 
     public static String getVersionDesc(int value) {
-        try {
-            Version v = Version.values()[value];
-            return v.name();
-        } catch (Exception e) {
+        int length = Version.values().length;
+        if (value >= length) {
+            return Version.values()[length - 1].name();
         }
 
-        return "HigherVersion";
+        return Version.values()[value].name();
     }
 
     public static Version value2Version(int value) {
+        int length = Version.values().length;
+        if (value >= length) {
+            return Version.values()[length - 1];
+        }
+
         return Version.values()[value];
     }
 
@@ -935,5 +939,7 @@ public class MQVersion {
 
         V5_9_9_SNAPSHOT,
         V5_9_9,
+
+        HIGHER_VERSION
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/MQVersionTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MQVersionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.common;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MQVersionTest {
+
+    @Test
+    public void testGetVersionDesc() throws Exception {
+        String desc = "V3_0_0_SNAPSHOT";
+        assertThat(MQVersion.getVersionDesc(0)).isEqualTo(desc);
+    }
+
+    @Test
+    public void testGetVersionDesc_higherVersion() throws Exception {
+        String desc = "HIGHER_VERSION";
+        assertThat(MQVersion.getVersionDesc(Integer.MAX_VALUE)).isEqualTo(desc);
+    }
+
+    @Test
+    public void testValue2Version() throws Exception {
+        assertThat(MQVersion.value2Version(0)).isEqualTo(MQVersion.Version.V3_0_0_SNAPSHOT);
+    }
+
+
+    @Test
+    public void testValue2Version_HigherVersion() throws Exception {
+        assertThat(MQVersion.value2Version(Integer.MAX_VALUE)).isEqualTo(MQVersion.Version.HIGHER_VERSION);
+    }
+}


### PR DESCRIPTION
When register higher version brokers again old name servers, index out of boundary exception is thrown, causing registration failure.
