### PR TITLE
[ROCKETMQ-187]Measure the code coverage for Integration Tests, and add sonar-apache profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ script:
 
 after_success:
   - mvn clean install -Pit-test
-  - mvn sonar:sonar
+  - mvn sonar:sonar -Psonar-apache

--- a/pom.xml
+++ b/pom.xml
@@ -161,10 +161,10 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-        <!-- URL of the ASF SonarQube server -->
-        <sonar.host.url>https://builds.apache.org/analysis</sonar.host.url>
         <!-- Exclude all generated code -->
-        <sonar.exclusions>file:**/generated-sources/**</sonar.exclusions>
+        <sonar.jacoco.itReportPath>${project.basedir}/../test/target/jacoco-it.exec</sonar.jacoco.itReportPath>
+        <sonar.exclusions>file:**/generated-sources/**,**/test/**</sonar.exclusions>
+
     </properties>
 
     <modules>
@@ -477,6 +477,13 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>sonar-apache</id>
+            <properties>
+                <!-- URL of the ASF SonarQube server -->
+                <sonar.host.url>https://builds.apache.org/analysis</sonar.host.url>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ROCKETMQ-187

Now we could browse the Unit Tests and IT Tests at 
https://builds.apache.org/analysis/component_measures/?id=org.apache.rocketmq%3Arocketmq-all
But the IT Test coverage is not correct. It should cover the original sources instead of the the classes in test module.
As for as I known, the coverage report is generated by matching the collected data(often using java agent) against a set of classes (the module classes compiled from src/main/). you could refer to: http://olafsblog.sysbsb.de/measuring-test-coverage-of-integration-tests-for-separated-modules-with-jacoco/
So we could match the jacoco-it.exec to each module's source classes to get the correct IT coverage report.
By the way, we'd better exclude the classes in the test module.


we may use sonar locally.  
So we'd better use profile to handle different occasions
