### PR TITLE
[ROCKETMQ-198]add LanguageCode for GO and PHP

### DIFF
--- a/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/LanguageCode.java
+++ b/remoting/src/main/java/org/apache/rocketmq/remoting/protocol/LanguageCode.java
@@ -26,7 +26,9 @@ public enum LanguageCode {
     ERLANG((byte) 5),
     RUBY((byte) 6),
     OTHER((byte) 7),
-    HTTP((byte) 8);
+    HTTP((byte) 8),
+    GO((byte) 9),
+    PHP((byte) 10);
 
     private byte code;
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ROCKETMQ-198
LanguageCode without GO. The language can only use OTHER
![go-client-consumer-detail](https://raw.githubusercontent.com/StyleTang/self-test/master/pic/go-client-consumer-detail-new.png)
[Go-Client's implement](https://github.com/apache/incubator-rocketmq-externals/pull/22)
[Go-Client's design](https://github.com/apache/incubator-rocketmq-externals/pull/19)