### PR TITLE
[ROCKETMQ-224] add rocketmq client log4j2 logging support

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -37,25 +37,17 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>rocketmq-common</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -37,13 +37,31 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>rocketmq-common</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
+++ b/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
@@ -30,25 +30,31 @@ public class ClientLogger {
     public static final String CLIENT_LOG_LEVEL = "rocketmq.client.logLevel";
     private static Logger log;
 
+    public static Class logClass = null;
+
     static {
         log = createLogger(LoggerName.CLIENT_LOGGER_NAME);
     }
 
+    public static Class getLogClass(){
+        return logClass;
+    }
+
     private static Logger createLogger(final String loggerName) {
         String logConfigFilePath =
-                System.getProperty("rocketmq.client.log.configFile",
-                        System.getenv("ROCKETMQ_CLIENT_LOG_CONFIGFILE"));
+            System.getProperty("rocketmq.client.log.configFile",
+                    System.getenv("ROCKETMQ_CLIENT_LOG_CONFIGFILE"));
         Boolean isloadconfig =
-                Boolean.parseBoolean(System.getProperty("rocketmq.client.log.loadconfig", "true"));
+            Boolean.parseBoolean(System.getProperty("rocketmq.client.log.loadconfig", "true"));
 
         final String log4JResourceFile =
-                System.getProperty("rocketmq.client.log4j.resource.fileName", "log4j_rocketmq_client.xml");
+            System.getProperty("rocketmq.client.log4j.resource.fileName", "log4j_rocketmq_client.xml");
 
         final String logbackResourceFile =
-                System.getProperty("rocketmq.client.logback.resource.fileName", "logback_rocketmq_client.xml");
+            System.getProperty("rocketmq.client.logback.resource.fileName", "logback_rocketmq_client.xml");
 
         final String log4J2ResourceFile =
-                System.getProperty("rocketmq.client.log4j2.resource.fileName", "log4j2_rocketmq_client.xml");
+            System.getProperty("rocketmq.client.log4j2.resource.fileName", "log4j2_rocketmq_client.xml");
 
         String clientLogRoot = System.getProperty(CLIENT_LOG_ROOT, "${user.home}/logs/rocketmqlogs");
         System.setProperty("client.logRoot", clientLogRoot);
@@ -86,11 +92,11 @@ public class ClientLogger {
                     if (null == logConfigFilePath) {
                         URL url = ClientLogger.class.getClassLoader().getResource(logbackResourceFile);
                         Method doConfigure =
-                                joranConfiguratoroObj.getClass().getMethod("doConfigure", URL.class);
+                            joranConfiguratoroObj.getClass().getMethod("doConfigure", URL.class);
                         doConfigure.invoke(joranConfiguratoroObj, url);
                     } else {
                         Method doConfigure =
-                                joranConfiguratoroObj.getClass().getMethod("doConfigure", String.class);
+                            joranConfiguratoroObj.getClass().getMethod("doConfigure", String.class);
                         doConfigure.invoke(joranConfiguratoroObj, logConfigFilePath);
                     }
 
@@ -103,6 +109,7 @@ public class ClientLogger {
                         initialize.invoke(joranConfigurator, "log4j2", logConfigFilePath);
                     }
                 }
+                logClass = classType;
             } catch (Exception e) {
                 System.err.println(e);
             }

--- a/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
+++ b/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
@@ -36,7 +36,7 @@ public class ClientLogger {
         log = createLogger(LoggerName.CLIENT_LOGGER_NAME);
     }
 
-    public static Class getLogClass(){
+    public static Class getLogClass() {
         return logClass;
     }
 

--- a/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
+++ b/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
@@ -31,11 +31,7 @@ public class ClientLogger {
 
     private static Logger log;
 
-    public static Class logClass = null;
-
-    public static Class getLogClass() {
-        return logClass;
-    }
+    private static Class logClass = null;
 
     private static Logger createLogger(final String loggerName) {
         String logConfigFilePath =

--- a/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
+++ b/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
@@ -28,13 +28,10 @@ public class ClientLogger {
     public static final String CLIENT_LOG_ROOT = "rocketmq.client.logRoot";
     public static final String CLIENT_LOG_MAXINDEX = "rocketmq.client.logFileMaxIndex";
     public static final String CLIENT_LOG_LEVEL = "rocketmq.client.logLevel";
+
     private static Logger log;
 
     public static Class logClass = null;
-
-    static {
-        log = createLogger(LoggerName.CLIENT_LOGGER_NAME);
-    }
 
     public static Class getLogClass() {
         return logClass;
@@ -118,7 +115,12 @@ public class ClientLogger {
     }
 
     public static Logger getLog() {
-        return log;
+        if (log == null) {
+            log = createLogger(LoggerName.CLIENT_LOGGER_NAME);
+            return log;
+        } else {
+            return log;
+        }
     }
 
     public static void setLog(Logger log) {

--- a/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
+++ b/client/src/main/java/org/apache/rocketmq/client/log/ClientLogger.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.client.log;
 
 import java.lang.reflect.Method;
 import java.net.URL;
+
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
@@ -35,16 +36,19 @@ public class ClientLogger {
 
     private static Logger createLogger(final String loggerName) {
         String logConfigFilePath =
-            System.getProperty("rocketmq.client.log.configFile",
-                System.getenv("ROCKETMQ_CLIENT_LOG_CONFIGFILE"));
+                System.getProperty("rocketmq.client.log.configFile",
+                        System.getenv("ROCKETMQ_CLIENT_LOG_CONFIGFILE"));
         Boolean isloadconfig =
-            Boolean.parseBoolean(System.getProperty("rocketmq.client.log.loadconfig", "true"));
+                Boolean.parseBoolean(System.getProperty("rocketmq.client.log.loadconfig", "true"));
 
         final String log4JResourceFile =
-            System.getProperty("rocketmq.client.log4j.resource.fileName", "log4j_rocketmq_client.xml");
+                System.getProperty("rocketmq.client.log4j.resource.fileName", "log4j_rocketmq_client.xml");
 
         final String logbackResourceFile =
-            System.getProperty("rocketmq.client.logback.resource.fileName", "logback_rocketmq_client.xml");
+                System.getProperty("rocketmq.client.logback.resource.fileName", "logback_rocketmq_client.xml");
+
+        final String log4J2ResourceFile =
+                System.getProperty("rocketmq.client.log4j2.resource.fileName", "log4j2_rocketmq_client.xml");
 
         String clientLogRoot = System.getProperty(CLIENT_LOG_ROOT, "${user.home}/logs/rocketmqlogs");
         System.setProperty("client.logRoot", clientLogRoot);
@@ -82,14 +86,22 @@ public class ClientLogger {
                     if (null == logConfigFilePath) {
                         URL url = ClientLogger.class.getClassLoader().getResource(logbackResourceFile);
                         Method doConfigure =
-                            joranConfiguratoroObj.getClass().getMethod("doConfigure", URL.class);
+                                joranConfiguratoroObj.getClass().getMethod("doConfigure", URL.class);
                         doConfigure.invoke(joranConfiguratoroObj, url);
                     } else {
                         Method doConfigure =
-                            joranConfiguratoroObj.getClass().getMethod("doConfigure", String.class);
+                                joranConfiguratoroObj.getClass().getMethod("doConfigure", String.class);
                         doConfigure.invoke(joranConfiguratoroObj, logConfigFilePath);
                     }
 
+                } else if (classType.getName().equals("org.apache.logging.slf4j.Log4jLoggerFactory")) {
+                    Class<?> joranConfigurator = Class.forName("org.apache.logging.log4j.core.config.Configurator");
+                    Method initialize = joranConfigurator.getDeclaredMethod("initialize", String.class, String.class);
+                    if (null == logConfigFilePath) {
+                        initialize.invoke(joranConfigurator, "log4j2", log4J2ResourceFile);
+                    } else {
+                        initialize.invoke(joranConfigurator, "log4j2", logConfigFilePath);
+                    }
                 }
             } catch (Exception e) {
                 System.err.println(e);

--- a/client/src/main/resources/log4j2_rocketmq_client.xml
+++ b/client/src/main/resources/log4j2_rocketmq_client.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<!DOCTYPE xml>
+<Configuration status="warn" name="RocketmqClient">
+    <Appenders>
+        <Console name="STDOUT-APPENDER">
+            <PatternLayout pattern="%-5p %c{2} , %m%n"/>
+        </Console>
+        <RollingFile name="RocketmqClientAppender" fileName="${sys:client.logRoot}/rocketmq_client.log"
+                     filePattern="${sys:client.logRoot}/rocketmq_client-%d{yyyy-MM-dd}-%i.log">
+            <PatternLayout pattern="%d{yyy-MM-dd HH\:mm\:ss,SSS} %p %c{1}(%L) - %m%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="1 GB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="${sys:client.logFileMaxIndex}"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <logger name="RocketmqClient" level="${sys:client.logLevel}" additivity="false">
+            <appender-ref ref="RocketmqClientAppender"/>
+        </logger>
+
+        <logger name="RocketmqCommon" level="${sys:client.logLevel}" additivity="false">
+            <appender-ref ref="RocketmqClientAppender"/>
+        </logger>
+
+        <logger name="RocketmqRemoting" level="${sys:client.logLevel}" additivity="false">
+            <appender-ref ref="RocketmqClientAppender"/>
+        </logger>
+    </Loggers>
+</Configuration>

--- a/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
@@ -17,14 +17,40 @@
 
 package org.apache.rocketmq.client.log;
 
+import com.sun.source.tree.AssertTree;
+import junit.framework.Assert;
 import org.junit.Test;
 
+import java.io.*;
 import java.util.Date;
 
 public class ClientLogTest {
 
+    public static final String CLIENT_LOG_ROOT = "rocketmq.client.logRoot";
+    public static final String LOG_DIR;
+
+    static {
+        LOG_DIR = System.getProperty(CLIENT_LOG_ROOT, "${user.home}/logs/rocketmqlogs");
+    }
+
     @Test
-    public void testLog4j2() {
-        ClientLogger.getLog().info("logg4j test " + new Date());
+    public void testLog4j2() throws IOException {
+        boolean result = false;
+        Class logClass = ClientLogger.getLogClass();
+        Assert.assertEquals("org.apache.logging.slf4j.Log4jLoggerFactory", logClass.getName());
+        for (int i = 0; i < 10; i++) {
+            ClientLogger.getLog().info("testcase testLog4j2 " + new Date());
+        }
+        File file = new File(LOG_DIR + File.separator + "rocketmq_client.log");
+        FileInputStream fileInputStream = new FileInputStream(file);
+        BufferedReader reader = new BufferedReader(new InputStreamReader(fileInputStream));
+        String line = reader.readLine();
+        while (line != null) {
+            if (line.contains("testcase testLog4j2")) {
+                result = true;
+                break;
+            }
+        }
+        Assert.assertTrue(result);
     }
 }

--- a/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.client.log;
+
+import org.junit.Test;
+
+import java.util.Date;
+
+public class ClientLogTest {
+
+    @Test
+    public void testLog4j2() {
+        ClientLogger.getLog().info("logg4j test " + new Date());
+    }
+}

--- a/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.client.log;
 
-import com.sun.source.tree.AssertTree;
 import junit.framework.Assert;
 import org.junit.Test;
 

--- a/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
+++ b/client/src/test/java/org/apache/rocketmq/client/log/ClientLogTest.java
@@ -34,22 +34,34 @@ public class ClientLogTest {
 
     @Test
     public void testLog4j2() throws IOException {
+        long seek = 0;
         boolean result = false;
+        File file = new File(LOG_DIR + File.separator + "rocketmq_client.log");
+        if (file.exists()) {
+            seek = file.length();
+        }
         Class logClass = ClientLogger.getLogClass();
         Assert.assertEquals("org.apache.logging.slf4j.Log4jLoggerFactory", logClass.getName());
         for (int i = 0; i < 10; i++) {
             ClientLogger.getLog().info("testcase testLog4j2 " + new Date());
         }
-        File file = new File(LOG_DIR + File.separator + "rocketmq_client.log");
-        FileInputStream fileInputStream = new FileInputStream(file);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(fileInputStream));
-        String line = reader.readLine();
+
+        RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
+        randomAccessFile.seek(seek);
+        String line = randomAccessFile.readLine();
+        int idx = 1;
         while (line != null) {
             if (line.contains("testcase testLog4j2")) {
                 result = true;
                 break;
             }
+            line = randomAccessFile.readLine();
+            idx++;
+            if (idx > 50) {
+                break;
+            }
         }
+        randomAccessFile.close();
         Assert.assertTrue(result);
     }
 }

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -41,10 +41,6 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -640,11 +640,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-api</artifactId>
-                <version>2.7</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
                 <version>2.7</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -576,7 +576,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.5</version>
+                <version>1.7.7</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
@@ -636,6 +636,16 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
+                <version>2.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>2.7</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
                 <version>2.7</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
When using RocketMQ client,we can only using logback or log4j for logging. If we using log4j2,there is no client log.
