### PR TITLE
[ROCKETMQ-234] bugfix - broker will write response twice in batch scenario

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/SendMessageProcessor.java
@@ -532,8 +532,7 @@ public class SendMessageProcessor extends AbstractSendMessageProcessor implement
 
         PutMessageResult putMessageResult = this.brokerController.getMessageStore().putMessages(messageExtBatch);
 
-        handlePutMessageResult(putMessageResult, response, request, messageExtBatch, responseHeader, sendMessageContext, ctx, queueIdInt);
-        return response;
+        return handlePutMessageResult(putMessageResult, response, request, messageExtBatch, responseHeader, sendMessageContext, ctx, queueIdInt);
     }
 
     public boolean hasConsumeMessageHook() {


### PR DESCRIPTION
Bug in handle batch response. It will write response twice to client in batch scenario.
Jira: [ROCKETMQ-234](https://issues.apache.org/jira/browse/ROCKETMQ-234)