### PR TITLE
[Rocketmq-285] file test error when make link

### DIFF
--- a/distribution/bin/os.sh
+++ b/distribution/bin/os.sh
@@ -59,6 +59,6 @@ cat /sys/block/$DISK/queue/scheduler
 if [ -d ${HOME}/tmpfs ] ; then
     echo "tmpfs exist, do nothing."
 else
-    ln -s /dev/shm tmpfs
+    ln -s /dev/shm ${HOME}/tmpfs
     echo "create tmpfs ok"
 fi


### PR DESCRIPTION
line 62.
cannot test ${HOME}/tmpfs while making link to ./tmpfs
change "ln -s /dev/shm tmpfs" to "ln -s /dev/shm ${HOME}/tmpfs"

https://issues.apache.org/jira/browse/ROCKETMQ-285
