### PR TITLE
[Rocketmq-277] fix get localhost throw java.net.UnknownHostException,when server hostname  not in /etc/hosts

### DIFF
--- a/common/src/main/java/org/apache/rocketmq/common/MixAll.java
+++ b/common/src/main/java/org/apache/rocketmq/common/MixAll.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
@@ -407,6 +408,36 @@ public class MixAll {
             InetAddress addr = InetAddress.getLocalHost();
             return addr.getHostAddress();
         } catch (Throwable e) {
+            try {
+                List<String> candidatesHost = new ArrayList<String>();
+                Enumeration<NetworkInterface> enumeration = NetworkInterface.getNetworkInterfaces();
+
+                while (enumeration.hasMoreElements()) {
+                    NetworkInterface networkInterface = enumeration.nextElement();
+                    if (networkInterface.isUp()) {
+                        Enumeration<InetAddress> addrs = networkInterface.getInetAddresses();
+                        while (addrs.hasMoreElements()) {
+                            InetAddress address = addrs.nextElement();
+                            if (address.isLoopbackAddress()) {
+                                continue;
+                            }
+                            //ip4 highter priority
+                            if (address instanceof Inet6Address) {
+                                candidatesHost.add(address.getHostAddress());
+                                continue;
+                            }
+                            return address.getHostAddress();
+                        }
+                    }
+                }
+
+                if (!candidatesHost.isEmpty()) {
+                    return candidatesHost.get(0);
+                }
+
+            } catch (Exception ignored) {
+            }
+
             throw new RuntimeException("InetAddress java.net.InetAddress.getLocalHost() throws UnknownHostException"
                 + FAQUrl.suggestTodo(FAQUrl.UNKNOWN_HOST_EXCEPTION),
                 e);

--- a/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
@@ -20,11 +20,8 @@ package org.apache.rocketmq.common;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.reflect.Method;
 import java.net.InetAddress;
-import java.nio.ByteOrder;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
@@ -92,5 +89,14 @@ public class MixAllTest {
         String fileName = System.getProperty("java.io.tmpdir") + File.separator + "MixAllTest" + System.currentTimeMillis();
         MixAll.string2File("MixAll_testString2File", fileName);
         assertThat(MixAll.file2String(fileName)).isEqualTo("MixAll_testString2File");
+    }
+
+    @Test
+    public void test_getLocalhostByNetworkInterface() throws Exception {
+        Method method = MixAll.class.getDeclaredMethod("getLocalhostByNetworkInterface");
+        method.setAccessible(true);
+        Object invoke = method.invoke(null);
+        System.out.println(invoke);
+        assertThat(invoke).isNotNull();
     }
 }

--- a/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/MixAllTest.java
@@ -96,7 +96,6 @@ public class MixAllTest {
         Method method = MixAll.class.getDeclaredMethod("getLocalhostByNetworkInterface");
         method.setAccessible(true);
         Object invoke = method.invoke(null);
-        System.out.println(invoke);
         assertThat(invoke).isNotNull();
     }
 }


### PR DESCRIPTION
Motivation:
 fix bug [ROCKETMQ-277](https://issues.apache.org/jira/browse/ROCKETMQ-277)
