### PR TITLE
[ROCKETMQ-289] getBrokerRuntimeInfo method output fileReservedTime value

### DIFF
--- a/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
+++ b/broker/src/main/java/org/apache/rocketmq/broker/processor/AdminBrokerProcessor.java
@@ -1207,6 +1207,7 @@ public class AdminBrokerProcessor implements NettyRequestProcessor {
 
         runtimeInfo.put("dispatchBehindBytes", String.valueOf(this.brokerController.getMessageStore().dispatchBehindBytes()));
         runtimeInfo.put("pageCacheLockTimeMills", String.valueOf(this.brokerController.getMessageStore().lockTimeMills()));
+        runtimeInfo.put("fileReservedTimeByHour", String.valueOf(this.brokerController.getMessageStoreConfig().getFileReservedTime()));
 
         runtimeInfo.put("sendThreadPoolQueueHeadWaitTimeMills", String.valueOf(this.brokerController.headSlowTimeMills4SendThreadPoolQueue()));
         runtimeInfo.put("pullThreadPoolQueueHeadWaitTimeMills", String.valueOf(this.brokerController.headSlowTimeMills4PullThreadPoolQueue()));


### PR DESCRIPTION

Motivation:
add fileReservedTime value for getBrokerRuntimeInfo return   `runtimeInfo`

Modification:
getBrokerRuntimeInfo method add a key `fileReservedTimeByHour` mean fileReservedTime in `runtimeInfo`